### PR TITLE
Add missing .gitattributes for versioning.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+__init__.py export-subst
+setup.py export-subst


### PR DESCRIPTION
I think this will change the version reported by a github zip file from `None` to something like `0.0.0+gSHA-gitarchive`.

This would have the affect of there being no exception in #610, but the version check (`eldata = agg if ds_version > '0.5.0' else (xs, ys, agg.data)`) would I think return False.