### PR TITLE
Fix for zero sized arrays when resampling

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -399,8 +399,8 @@ class Canvas(object):
         if np.isclose(width_ratio, 0) or np.isclose(height_ratio, 0):
             raise ValueError('Canvas x_range or y_range values do not match closely enough with the data source to be able to accurately rasterize. Please provide ranges that are more accurate.')
 
-        w = max(int(np.ceil(self.plot_width * width_ratio)), 1)
-        h = max(int(np.ceil(self.plot_height * height_ratio)), 1)
+        w = max(int(round(self.plot_width * width_ratio)), 1)
+        h = max(int(round(self.plot_height * height_ratio)), 1)
         cmin, cmax = get_indices(xmin, xmax, xvals, res[0])
         rmin, rmax = get_indices(ymin, ymax, yvals, res[1])
 

--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -251,7 +251,9 @@ def _resample_2d(src, mask, use_mask, ds_method, us_method, fill_value, mode_ran
     downsampling_method = DOWNSAMPLING_METHODS[ds_method]
     upsampling_method = UPSAMPLING_METHODS[us_method]
 
-    if out_w < src_w and out_h < src_h:
+    if src_h == 0 or src_w == 0 or out_h == 0 or out_w == 0:
+       return np.zeros((out_h, out_w), dtype=src.dtype)
+    elif out_w < src_w and out_h < src_h:
         return downsampling_method(src, mask, use_mask, ds_method, fill_value, mode_rank, out)
     elif out_w < src_w:
         if out_h > src_h:


### PR DESCRIPTION
Small fix to handle zero sized input and output arrays when using Canvas.raster to resample an image.