### PR TITLE
Fix mapping onto pixel for line

### DIFF
--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -162,33 +162,8 @@ class Line(_PointLike):
     """
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-
-        @ngjit
-        def map_onto_pixel(vt, bounds, x, y):
-            """Map points onto pixel grid.
-
-            Points falling on upper bound are mapped into previous bin.
-
-            If the line has been clipped, x and y will have been
-            computed to lie on the bounds; we compare point and bounds
-            in integer space to avoid fp error. In contrast, with
-            auto-ranging, a point on the bounds will be the same
-            floating point number as the bound, so comparison in fp
-            representation of continuous space or in integer space
-            doesn't change anything.
-            """
-            sx, tx, sy, ty = vt
-            xmax, ymax = bounds[1], bounds[3]
-            xx = int(x_mapper(x) * sx + tx)
-            yy = int(y_mapper(y) * sy + ty)
-
-            xxmax = int(x_mapper(xmax) * sx + tx)
-            yymax = int(y_mapper(ymax) * sy + ty)
-
-            return (xx - 1 if xx == xxmax else xx,
-                    yy - 1 if yy == yymax else yy)
-
         draw_line = _build_draw_line(append)
+        map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         extend_line = _build_extend_line(draw_line, map_onto_pixel)
         x_name = self.x
         y_name = self.y
@@ -213,21 +188,8 @@ class Triangles(_PolygonLike):
     """
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-        
-        @ngjit
-        def map_onto_pixel(vt, bounds, x, y):
-            """Map points onto pixel grid.
-
-            Points falling on upper bound are mapped into previous bin.
-            """
-            sx, tx, sy, ty = vt
-            xmax, ymax = bounds[1], bounds[3]
-            xx = int(x_mapper(x) * sx + tx)
-            yy = int(y_mapper(y) * sy + ty)
-            return (xx - 1 if x == xmax else xx,
-                    yy - 1 if y == ymax else yy)
-
         draw_triangle, draw_triangle_interp = _build_draw_triangle(append)
+        map_onto_pixel = _build_map_onto_pixel_for_triangle(x_mapper, y_mapper)
         extend_triangles = _build_extend_triangles(draw_triangle, draw_triangle_interp, map_onto_pixel)
 
         def extend(aggs, df, vt, bounds, weight_type=True, interpolate=True):
@@ -241,6 +203,52 @@ class Triangles(_PolygonLike):
 
 
 # -- Helpers for computing geometries --
+
+
+def _build_map_onto_pixel_for_line(x_mapper, y_mapper):
+    @ngjit
+    def map_onto_pixel(vt, bounds, x, y):
+        """Map points onto pixel grid.
+
+        Points falling on upper bound are mapped into previous bin.
+
+        If the line has been clipped, x and y will have been
+        computed to lie on the bounds; we compare point and bounds
+        in integer space to avoid fp error. In contrast, with
+        auto-ranging, a point on the bounds will be the same
+        floating point number as the bound, so comparison in fp
+        representation of continuous space or in integer space
+        doesn't change anything.
+        """
+        sx, tx, sy, ty = vt
+        xmax, ymax = bounds[1], bounds[3]
+        xx = int(x_mapper(x) * sx + tx)
+        yy = int(y_mapper(y) * sy + ty)
+
+        xxmax = int(x_mapper(xmax) * sx + tx)
+        yymax = int(y_mapper(ymax) * sy + ty)
+
+        return (xx - 1 if xx == xxmax else xx,
+                yy - 1 if yy == yymax else yy)
+
+    return map_onto_pixel
+
+
+def _build_map_onto_pixel_for_triangle(x_mapper, y_mapper):
+    @ngjit
+    def map_onto_pixel(vt, bounds, x, y):
+        """Map points onto pixel grid.
+
+        Points falling on upper bound are mapped into previous bin.
+        """
+        sx, tx, sy, ty = vt
+        xmax, ymax = bounds[1], bounds[3]
+        xx = int(x_mapper(x) * sx + tx)
+        yy = int(y_mapper(y) * sy + ty)
+        return (xx - 1 if x == xmax else xx,
+                yy - 1 if y == ymax else yy)
+    return map_onto_pixel
+
 
 
 def _build_draw_line(append):

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -206,9 +206,14 @@ def _build_map_onto_pixel(x_mapper, y_mapper):
         xmax, ymax = bounds[1], bounds[3]
         xx = int(x_mapper(x) * sx + tx)
         yy = int(y_mapper(y) * sy + ty)
+
+        # TODO before merge: check for same elsewhere
+        xxmax = int(x_mapper(xmax) * sx + tx)
+        yymax = int(y_mapper(ymax) * sy + ty)
+
         # Points falling on upper bound are mapped into previous bin
-        return (xx - 1 if x == xmax else xx,
-                yy - 1 if y == ymax else yy)
+        return (xx - 1 if xx == xxmax else xx,
+                yy - 1 if yy == yymax else yy)
 
     return map_onto_pixel
 

--- a/datashader/tests/benchmarks/test_extend_line.py
+++ b/datashader/tests/benchmarks/test_extend_line.py
@@ -2,7 +2,7 @@ import pytest
 
 import numpy as np
 
-from datashader.glyphs import _build_draw_line, _build_extend_line, _build_map_onto_pixel
+from datashader.glyphs import _build_draw_line, _build_extend_line, _build_map_onto_pixel_for_line
 from datashader.utils import ngjit
 
 
@@ -13,7 +13,7 @@ def extend_line():
         agg[y, x] += 1
 
     mapper = ngjit(lambda x: x)
-    map_onto_pixel = _build_map_onto_pixel(mapper, mapper)
+    map_onto_pixel = _build_map_onto_pixel_for_line(mapper, mapper)
     draw_line = _build_draw_line(append)
     return _build_extend_line(draw_line, map_onto_pixel)
 

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -341,16 +341,24 @@ def test_draw_triangle_subpixel():
     np.testing.assert_equal(agg, out)
 
 
-def test_temp():
+def test_awkward_point_on_upper_bound_maps_to_last_pixel():
+    """Check that point deliberately chosen to be on the upper bound but
+    with a similar-magnitudes subtraction error like that which could
+    occur in extend line does indeed get mapped to last pixel.
+    """
     num_y_pixels = 2
     ymax = 0.1
     bigy = 10e9
     
     sy = num_y_pixels/ymax
-    y = bigy-(bigy-ymax)
+    y = bigy-(bigy-ymax) # simulates clipped line
+
+    # check that test is set up ok
+    assert y!=ymax
+    np.testing.assert_almost_equal(y,ymax,decimal=6)
     
-    _,pymax = map_onto_pixel((1.0,0.0,sy,0.0),
+    _,pymax = map_onto_pixel((1.0, 0.0, sy, 0.0),
                              (0.0, 1.0, 0.0, ymax),
-                             1.0 , y)
+                             1.0, y)
 
     assert pymax==num_y_pixels-1

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -339,3 +339,18 @@ def test_draw_triangle_subpixel():
     draw_triangle(tri[3:6], (2, 2, 3, 3), (0, 0, 0), agg, 2)
     draw_triangle(tri[6:], (2, 2, 3, 3), (0, 0, 0), agg, 2)
     np.testing.assert_equal(agg, out)
+
+
+def test_temp():
+    num_y_pixels = 2
+    ymax = 0.1
+    bigy = 10e9
+    
+    sy = num_y_pixels/ymax
+    y = bigy-(bigy-ymax)
+    
+    _,pymax = map_onto_pixel((1.0,0.0,sy,0.0),
+                             (0.0, 1.0, 0.0, ymax),
+                             1.0 , y)
+
+    assert pymax==num_y_pixels-1

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -3,9 +3,9 @@ import pandas as pd
 import numpy as np
 import pytest
 
-from datashader.glyphs import (Point, _build_draw_line, _build_map_onto_pixel,
+from datashader.glyphs import (Point, _build_draw_line, _build_map_onto_pixel_for_line,
                                _build_extend_line, _build_draw_triangle,
-                               _build_extend_triangles)
+                               _build_map_onto_pixel_for_triangle, _build_extend_triangles)
 from datashader.utils import ngjit
 
 
@@ -37,15 +37,16 @@ def new_agg():
 
 
 mapper = ngjit(lambda x: x)
-map_onto_pixel = _build_map_onto_pixel(mapper, mapper)
+map_onto_pixel_for_line = _build_map_onto_pixel_for_line(mapper, mapper)
+map_onto_pixel_for_triangle = _build_map_onto_pixel_for_triangle(mapper, mapper)
 
 # Line rasterization
 draw_line = _build_draw_line(append)
-extend_line = _build_extend_line(draw_line, map_onto_pixel)
+extend_line = _build_extend_line(draw_line, map_onto_pixel_for_line)
 
 # Triangles rasterization
 draw_triangle, draw_triangle_interp = _build_draw_triangle(tri_append)
-extend_triangles = _build_extend_triangles(draw_triangle, draw_triangle_interp, map_onto_pixel)
+extend_triangles = _build_extend_triangles(draw_triangle, draw_triangle_interp, map_onto_pixel_for_triangle)
 
 bounds = (-3, 1, -3, 1)
 vt = (1., 3., 1., 3.)
@@ -341,7 +342,7 @@ def test_draw_triangle_subpixel():
     np.testing.assert_equal(agg, out)
 
 
-def test_awkward_point_on_upper_bound_maps_to_last_pixel():
+def test_line_awkward_point_on_upper_bound_maps_to_last_pixel():
     """Check that point deliberately chosen to be on the upper bound but
     with a similar-magnitudes subtraction error like that which could
     occur in extend line does indeed get mapped to last pixel.
@@ -357,8 +358,8 @@ def test_awkward_point_on_upper_bound_maps_to_last_pixel():
     assert y!=ymax
     np.testing.assert_almost_equal(y,ymax,decimal=6)
     
-    _,pymax = map_onto_pixel((1.0, 0.0, sy, 0.0),
-                             (0.0, 1.0, 0.0, ymax),
-                             1.0, y)
+    _,pymax = map_onto_pixel_for_line((1.0, 0.0, sy, 0.0),
+                                      (0.0, 1.0, 0.0, ymax),
+                                      1.0, y)
 
     assert pymax==num_y_pixels-1


### PR DESCRIPTION
Previously, when a line was clipped, the computed end point on the bounds could be mapped to a pixel outside the bounds because of floating point error. This showed up as #570.

There should be no change for points or triangles. However: 
  * triangles and lines can no longer share a 'map onto pixel' function
  * I've added some comments to points and triangles.

The code changes and comments should be reviewed carefully.

(The various 'build map for x' (and similar) functions seem a bit clumsy; should consider reorganizing the code a bit in the future. Have avoided doing that here so as not to confuse things.)