### PR TITLE
WIP: Packaging updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ jobs:
       before_install: pip install pyctdev && doit ecosystem=pip ecosystem_setup
       install:
         - unset PYENV_VERSION && pyenv global 3.6 2.7
-        - doit ecosystem=pip package_build $PKG_TEST_PYTHON --test-group=all
+        - doit ecosystem=pip package_build $PKG_TEST_PYTHON --test-group=all --sdist-install-build-deps
       script: doit ecosystem=pip package_upload -u $PYPIUSER -p $PYPIPASS --pypi ${PYPI}
 
     - &conda_pkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
     - PYENV_VERSION=3.6
     - CHANS_DEV="-c pyviz/label/dev"
     - CHANS_REL="-c pyviz"
+    - LABELS_DEV="--label dev"
+    - LABELS_REL="--label dev --label main"
     - PKG_TEST_PYTHON="--test-python=py27 --test-python=py36"
     # conda build fills up travis /tmp (tmpfs)
     - TMPDIR=$HOME/tmp
@@ -32,13 +34,13 @@ before_cache:
 stages:
   - test
   - name: conda_dev_package
-    if: tag =~ ^v(\d+|\.)*[a-z]\d*$
+    if: tag =~ ^v(\d+|\.)+[a-z]\d+$
   - name: pip_dev_package
-    if: tag =~ ^v(\d+|\.)*[a-z]\d*$
+    if: tag =~ ^v(\d+|\.)+[a-z]\d+$
   - name: conda_package
-    if: tag =~ ^v(\d+|\.)*[^a-z]\d*$
+    if: tag =~ ^v(\d+|\.)+[^a-z]\d+$
   - name: pip_package
-    if: tag =~ ^v(\d+|\.)*[^a-z]\d*$
+    if: tag =~ ^v(\d+|\.)+[^a-z]\d+$
 
 jobs:
   include:
@@ -76,36 +78,31 @@ jobs:
 
     ## dev packages
 
-    - env: PYPI="https://test.pypi.org/legacy/" TRAVIS_NOCACHE=$TRAVIS_JOB_ID
+    - &pip_default
+      env: PYPI=testpypi PYPIUSER=$TPPU PYPIPASS=$TPPP TRAVIS_NOCACHE=$TRAVIS_JOB_ID
       stage: pip_dev_package
       before_install: pip install pyctdev && doit ecosystem=pip ecosystem_setup
       install:
         - unset PYENV_VERSION && pyenv global 3.6 2.7
         - doit ecosystem=pip package_build $PKG_TEST_PYTHON --test-group=all
-      script: doit ecosystem=pip package_upload -u $TPPU -p $TPPP -r ${PYPI}
+      script: doit ecosystem=pip package_upload -u $PYPIUSER -p $PYPIPASS --pypi ${PYPI}
 
-    - <<: *conda_default
+    - &conda_pkg
+      <<: *conda_default
       stage: conda_dev_package
-      env: DESC="" TRAVIS_NOCACHE=$TRAVIS_JOB_ID
-      install: doit package_build $CHANS_DEV $PKG_TEST_PYTHON --test-group=all
-      script: doit package_upload --token=$CONDA_UPLOAD_TOKEN --label=dev
+      env: DESC="" LABELS=$LABELS_DEV CHANS=$CHANS_DEV TRAVIS_NOCACHE=$TRAVIS_JOB_ID
+      install: doit package_build $CHANS $PKG_TEST_PYTHON --test-group=all
+      script: doit package_upload --token=$CONDA_UPLOAD_TOKEN $LABELS
 
     ## release packages
 
-    - env: TRAVIS_NOCACHE=$TRAVIS_JOB_ID
+    - <<: *pip_default
+      env: PYPI=pypi PYPIUSER=$PPU PYPIPASS=$PPP TRAVIS_NOCACHE=$TRAVIS_JOB_ID
       stage: pip_package
-      before_install: pip install pyctdev && doit ecosystem=pip ecosystem_setup
-      install:
-        - unset PYENV_VERSION && pyenv global 3.6 2.7
-        - doit ecosystem=pip package_build $PKG_TEST_PYTHON --test-group=all
-      script: doit ecosystem=pip package_upload -u $PPU -p $PPP -r ${PYPI}
 
-    - <<: *conda_default
+    - <<: *conda_pkg
       stage: conda_package
-      env: DESC="" TRAVIS_NOCACHE=$TRAVIS_JOB_ID
-      install: doit package_build $CHANS_REL $PKG_TEST_PYTHON --test-group=all
-      script: doit package_upload --token=$CONDA_UPLOAD_TOKEN  --label=dev --label=main
-
+      env: DESC="" LABELS=$LABELS_REL CHANS=$CHANS_REL TRAVIS_NOCACHE=$TRAVIS_JOB_ID
 
 notifications:
   email: false

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include LICENSE.txt
 include README.md
 include datashader/.version
 graft examples
+graft datashader/examples
 graft datashader/tests/data
 global-exclude *.py[co]
 global-exclude *~

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -20,9 +20,9 @@ build:
 requirements:
   build:
     - python {{ sdata['python_requires'] }}
-    {% for dep in sdata['extras_require']['build'] %}
-    - {{ dep }}
-    {% endfor %}  
+    - param >=1.7.0
+    - pyct >=0.4.4
+    - setuptools >30.3.0
   run:
     - python {{ sdata['python_requires'] }}
     {% for dep in sdata.get('install_requires',{}) %}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -28,6 +28,8 @@ requirements:
     {% for dep in sdata.get('install_requires',{}) %}
     - {{ dep }}
     {% endfor %}
+    # adding pyct here is temporary (this conda recipe template will disappear when new pyctdev is released)
+    - pyct
 
 test:
   imports:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   build:
     - python {{ sdata['python_requires'] }}
     - param >=1.7.0
-    - pyct >=0.4.4
+    - pyct-core >=0.4.4
     - setuptools >30.3.0
   run:
     - python {{ sdata['python_requires'] }}

--- a/datashader/__init__.py
+++ b/datashader/__init__.py
@@ -19,12 +19,12 @@ except ImportError:
 # make pyct's example/data commands available if possible
 from functools import partial
 try:
-    from pvutil.cmd import copy_examples as _copy, fetch_data as _fetch, examples as _examples
+    from pyct.cmd import copy_examples as _copy, fetch_data as _fetch, examples as _examples
     copy_examples = partial(_copy,'datashader')
     fetch_data = partial(_fetch,'datashader')
     examples = partial(_examples,'datashader')
 except ImportError:
-    def _missing_cmd(*args,**kw): return("install pyct to enable this command (e.g. `conda install pyct`)")
+    def _missing_cmd(*args,**kw): return("install pyct to enable this command (e.g. `conda install pyct or `pip install pyct[cmd]`)")
     _copy = _fetch = _examples = _missing_cmd
     def err(): raise ValueError(_missing_cmd())
     fetch_data = copy_examples = examples = err

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "param >=1.7.0",
+    "pyct >=0.4.4",
+    "setuptools >=30.3.0"
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[metadata]
+license_file = LICENSE.txt
+
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,122 +1,10 @@
 import os,sys
 import shutil
-from collections import defaultdict
 from setuptools import find_packages, setup
 
-
-########## autover ##########
-
-def embed_version(basepath, ref='v0.2.2'):
-    """
-    Autover is purely a build time dependency in all cases (conda and
-    pip) except for when you use pip's remote git support [git+url] as
-    1) you need a dynamically changing version and 2) the environment
-    starts off clean with zero dependencies installed.
-    This function acts as a fallback to make Version available until
-    PEP518 is commonly supported by pip to express build dependencies.
-    """
-    import io, zipfile, importlib
-    try:    from urllib.request import urlopen
-    except: from urllib import urlopen
-    try:
-        url = 'https://github.com/ioam/autover/archive/{ref}.zip'
-        response = urlopen(url.format(ref=ref))
-        zf = zipfile.ZipFile(io.BytesIO(response.read()))
-        ref = ref[1:] if ref.startswith('v') else ref
-        embed_version = zf.read('autover-{ref}/autover/version.py'.format(ref=ref))
-        with open(os.path.join(basepath, 'version.py'), 'wb') as f:
-            f.write(embed_version)
-        return importlib.import_module("version")
-    except:
-        return None
-
-def get_setup_version(reponame):
-    """
-    Helper to get the current version from either git describe or the
-    .version file (if available).
-    """
-    import json
-    basepath = os.path.split(__file__)[0]
-    version_file_path = os.path.join(basepath, reponame, '.version')
-    try:
-        from param import version
-    except:
-        version = embed_version(basepath)
-    if version is not None:
-        return version.Version.setup_version(basepath, reponame, archive_commit="$Format:%h$")
-    else:
-        print("WARNING: param>=1.6.0 unavailable. If you are installing a package, this warning can safely be ignored. If you are creating a package or otherwise operating in a git repository, you should install param>=1.6.0.")
-        return json.load(open(version_file_path, 'r'))['version_string']
-
-########## examples ##########
-
-def check_pseudo_package(path):
-    """
-    Verifies that a fake subpackage path for assets (notebooks, svgs,
-    pngs etc) both exists and is populated with files.
-    """
-    if not os.path.isdir(path):
-        raise Exception("Please make sure pseudo-package %s exists." % path)
-    else:
-        assets = os.listdir(path)
-        if len(assets) == 0:
-            raise Exception("Please make sure pseudo-package %s is populated." % path)
-
-
-excludes = ['DS_Store', '.log', 'ipynb_checkpoints']
-packages = []
-extensions = defaultdict(list)
-
-def walker(top, names):
-    """
-    Walks a directory and records all packages and file extensions.
-    """
-    global packages, extensions
-    if any(exc in top for exc in excludes):
-        return
-    package = top[top.rfind('datashader'):].replace(os.path.sep, '.')
-    packages.append(package)
-    for name in names:
-        ext = '.'.join(name.split('.')[1:])
-        ext_str = '*.%s' % ext
-        if ext and ext not in excludes and ext_str not in extensions[package]:
-            extensions[package].append(ext_str)
-
-
-def examples(path='datashader-examples', verbose=False, force=False, root=__file__):
-    """
-    Copies the notebooks to the supplied path.
-    """
-    filepath = os.path.abspath(os.path.dirname(root))
-    example_dir = os.path.join(filepath, './examples')
-    if not os.path.exists(example_dir):
-        example_dir = os.path.join(filepath, '../examples')
-    if os.path.exists(path):
-        if not force:
-            print('%s directory already exists, either delete it or set the force flag' % path)
-            return
-        shutil.rmtree(path)
-    ignore = shutil.ignore_patterns('.ipynb_checkpoints', '*.pyc', '*~')
-    tree_root = os.path.abspath(example_dir)
-    if os.path.isdir(tree_root):
-        shutil.copytree(tree_root, path, ignore=ignore, symlinks=True)
-    else:
-        print('Cannot find %s' % tree_root)
-
-
-
-def package_assets(example_path):
-    """
-    Generates pseudo-packages for the examples directory.
-    """
-    examples(example_path, force=True, root=__file__)
-    for root, dirs, files in os.walk(example_path):
-        walker(root, dirs+files)
-    setup_args['packages'] += packages
-    for p, exts in extensions.items():
-        if exts:
-            setup_args['package_data'][p] = exts
-
+# build dependencies
+import param
+import pyct.build
 
 ########## dependencies ##########
 
@@ -134,7 +22,7 @@ install_requires = [
     'xarray >=0.9.6',
     'colorcet >=0.9.0',
     'param >=1.6.0',
-    'pyct',
+    'pyct[cmd]',
     'scikit-image',
     'bokeh',
     'scipy'
@@ -166,7 +54,6 @@ extras_require = {
         'requests',
         'tblib',
         'xarray',
-        'pvutil',
         'pyyaml',
         'streamz ==0.2.0',
         'webargs',
@@ -189,27 +76,20 @@ extras_require = {
 }
 
 extras_require['doc'] = extras_require['examples_extra'] + [
-    'nbsite',
+    'nbsite >=0.4.4',
     'sphinx_ioam_theme',
     'numpydoc'
 ]
 
 extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
 
-# until pyproject.toml/equivalent is widely supported; meanwhile
-# setup_requires doesn't work well with pip. Note: deliberately
-# omitted from all.
-extras_require['build'] = [
-    'param >=1.6.1',
-    'setuptools' # should make this pip now
-]
 
 
 ########## metadata for setuptools ##########
 
 setup_args = dict(
     name='datashader',
-    version=get_setup_version("datashader"),
+    version=param.version.get_setup_version("datashader",archive_commit="$Format:%h$"),
     description='Data visualization toolchain based on aggregating into a grid',
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",    
@@ -221,8 +101,8 @@ setup_args = dict(
     extras_require=extras_require,
     tests_require=extras_require['tests'],
     license='New BSD',
-    packages=find_packages()+packages,
-    package_data={'datashader': ['.version']},    
+    packages=find_packages(),
+    include_package_data = True,
     entry_points={
         'console_scripts': [
             'datashader = datashader.__main__:main'
@@ -234,6 +114,7 @@ if __name__ == '__main__':
     example_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                 'datashader','examples')
     if 'develop' not in sys.argv:
+        pyct.build.examples(example_path, __file__, force=True)
         package_assets(example_path)
 
     setup(**setup_args)

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
 
 setup_args = dict(
     name='datashader',
-    version=param.version.get_setup_version(os.path.split(__file__)[0],"datashader",archive_commit="$Format:%h$"),
+    version=param.version.get_setup_version(__file__,"datashader",archive_commit="$Format:%h$"),
     description='Data visualization toolchain based on aggregating into a grid',
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",    

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
 
 setup_args = dict(
     name='datashader',
-    version=param.version.get_setup_version("datashader",archive_commit="$Format:%h$"),
+    version=param.version.get_setup_version(os.path.split(__file__)[0],"datashader",archive_commit="$Format:%h$"),
     description='Data visualization toolchain based on aggregating into a grid',
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",    
@@ -115,7 +115,6 @@ if __name__ == '__main__':
                                 'datashader','examples')
     if 'develop' not in sys.argv:
         pyct.build.examples(example_path, __file__, force=True)
-        package_assets(example_path)
 
     setup(**setup_args)
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@
 [tox]
 #          python version                     test group            extra envs  extra commands       
 envlist = {py27,py35,py36}-{lint,unit,examples,all,examples_extra}-{default}-{dev,pkg}
+build = wheel
 
 [_lint]
 description = Flake check python and notebooks, and verify notebooks


### PR DESCRIPTION
* Use pyproject.toml for declaring build dependencies
* Use param for setup.py version (should be no change in behavior: same autover functions as before, they're just in param)
* Use pyct for packaging examples (should be no change in behavior: same hv functions as before, they're just in pyct).
* Use pyct for user example commands (should be little or no change in behavior: was previously using a prototype of pyct, pvutil)
* Travis tag detection now matches pyviz standard tags (shouldn't have any practical effect for datashader)
* Simplified travis release vs dev packages (re-used more code; should be no change to behavior).

Still more work to do in the future:
  * use setup.cfg to declare setup data
  * use setup.cfg to define conda package(s) (next release of pyctdev will include a default conda recipe template, which should be able to replace the one in this repository and generate multiple packages if that's ever required for datashader)
