### PR TITLE
Added handling for zero data and zero range

### DIFF
--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -40,10 +40,10 @@ class _PointLike(Glyph):
                     maxval = x
 
         if not (np.isfinite(minval) and np.isfinite(maxval)):
-            print("No x values; defaulting to range -0.5,0.5")
+            #print("No x values; defaulting to range -0.5,0.5")
             minval, maxval = -0.5, 0.5
         elif minval==maxval:
-            print("No x range; defaulting to x-0.5,x+0.5")
+            #print("No x range; defaulting to x-0.5,x+0.5")
             minval, maxval = minval-0.5, minval+0.5
         return minval, maxval
 
@@ -60,10 +60,10 @@ class _PointLike(Glyph):
                     maxval = y
 
         if not (np.isfinite(minval) and np.isfinite(maxval)):
-            print("No y values; defaulting to range -0.5,0.5")
+            #print("No y values; defaulting to range -0.5,0.5")
             minval, maxval = -0.5, 0.5
         elif minval==maxval:
-            print("No y range; defaulting to y-0.5,y+0.5")
+            #print("No y range; defaulting to y-0.5,y+0.5")
             minval, maxval = minval-0.5, minval+0.5
         return minval, maxval
 
@@ -76,10 +76,10 @@ class _PointLike(Glyph):
         minval, maxval = np.nanmin(xs), np.nanmax(xs)
         
         if minval == np.nan and maxval == np.nan:
-            print("No x values; defaulting to range -0.5,0.5")
+            #print("No x values; defaulting to range -0.5,0.5")
             minval, maxval = -0.5, 0.5
         elif minval==maxval:
-            print("No x range; defaulting to x-0.5,x+0.5")
+            #print("No x range; defaulting to x-0.5,x+0.5")
             minval, maxval = minval-0.5, minval+0.5
         return minval, maxval
         
@@ -93,10 +93,10 @@ class _PointLike(Glyph):
         minval, maxval = np.nanmin(ys), np.nanmax(ys)
         
         if minval == np.nan and maxval == np.nan:
-            print("No y values; defaulting to range -0.5,0.5")
+            #print("No y values; defaulting to range -0.5,0.5")
             minval, maxval = -0.5, 0.5
         elif minval==maxval:
-            print("No y range; defaulting to y-0.5,y+0.5")
+            #print("No y range; defaulting to y-0.5,y+0.5")
             minval, maxval = minval-0.5, minval+0.5
         return minval, maxval
 

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -38,8 +38,13 @@ class _PointLike(Glyph):
                     minval = x
                 if x > maxval:
                     maxval = x
+
         if not (np.isfinite(minval) and np.isfinite(maxval)):
-            raise ValueError('No non-NaN x coordinates found.')
+            print("No x values; defaulting to range -0.5,0.5")
+            minval, maxval = -0.5, 0.5
+        elif minval==maxval:
+            print("No x range; defaulting to x-0.5,x+0.5")
+            minval, maxval = minval-0.5, minval+0.5
         return minval, maxval
 
     @staticmethod
@@ -53,8 +58,13 @@ class _PointLike(Glyph):
                     minval = y
                 if y > maxval:
                     maxval = y
+
         if not (np.isfinite(minval) and np.isfinite(maxval)):
-            raise ValueError('No non-NaN y coordinates found.')
+            print("No y values; defaulting to range -0.5,0.5")
+            minval, maxval = -0.5, 0.5
+        elif minval==maxval:
+            print("No y range; defaulting to y-0.5,y+0.5")
+            minval, maxval = minval-0.5, minval+0.5
         return minval, maxval
 
     @memoize
@@ -63,7 +73,16 @@ class _PointLike(Glyph):
         ``df`` is immutable/hashable (a Dask dataframe).
         """
         xs = df[self.x].values
-        return np.nanmin(xs), np.nanmax(xs)
+        minval, maxval = np.nanmin(xs), np.nanmax(xs)
+        
+        if minval == np.nan and maxval == np.nan:
+            print("No x values; defaulting to range -0.5,0.5")
+            minval, maxval = -0.5, 0.5
+        elif minval==maxval:
+            print("No x range; defaulting to x-0.5,x+0.5")
+            minval, maxval = minval-0.5, minval+0.5
+        return minval, maxval
+        
 
     @memoize
     def _compute_y_bounds_dask(self, df):
@@ -71,7 +90,16 @@ class _PointLike(Glyph):
         ``df`` is immutable/hashable (a Dask dataframe).
         """
         ys = df[self.y].values
-        return np.nanmin(ys), np.nanmax(ys)
+        minval, maxval = np.nanmin(ys), np.nanmax(ys)
+        
+        if minval == np.nan and maxval == np.nan:
+            print("No y values; defaulting to range -0.5,0.5")
+            minval, maxval = -0.5, 0.5
+        elif minval==maxval:
+            print("No y range; defaulting to y-0.5,y+0.5")
+            minval, maxval = minval-0.5, minval+0.5
+        return minval, maxval
+
 
 
 class _PolygonLike(_PointLike):


### PR DESCRIPTION
Previously, Datashader would return ZeroDivision or other errors in all of these cases:

- No datapoints (common when interactively zooming into a small region, so should be valid)
- A single datapoint (which caused the x and y ranges to be infinitely small)
- Multiple datapoints sharing a single x or y value (which caused either the x or y ranges to be infinitely small)

The case with two distinct points has always worked, but the rest give errors:

```
import pandas as pd, datashader as ds, datashader.transfer_functions as tf
cvs = ds.Canvas(plot_width=5, plot_height=5)
df = pd.DataFrame(dict(x=[1,2], y=[-2,-5]))
print(str(cvs.points(df,'x','y').values))

[[0 0 0 0 1]
 [0 0 0 0 0]
 [0 0 0 0 0]
 [0 0 0 0 0]
 [1 0 0 0 0]]
```

No data points:

```
df = pd.DataFrame(dict(x=[], y=[]))
print(str(cvs.points(df,'x','y').values))

ValueError: No non-NaN x coordinates found.
```

A single data point:

```
df = pd.DataFrame(dict(x=[1], y=[-2]))
print(str(cvs.points(df,'x','y').values))

ZeroDivisionError: float division by zero
```

Two points, but only 1 x value:

```
df = pd.DataFrame(dict(x=[1,1], y=[-2,5]))
print(str(cvs.points(df,'x','y').values))

ZeroDivisionError: float division by zero
```

Two points, but only 1 y value:

```
df = pd.DataFrame(dict(x=[1,2], y=[-2,-2]))
print(str(cvs.points(df,'x','y').values))

ZeroDivisionError: float division by zero
```

Float array with one data point:

```
df = pd.DataFrame(dict(x=[1], y=[2]))
print(str(cvs.points(df,'x','y', agg=ds.sum('x')).values))

ZeroDivisionError: float division by zero
```



