### PR TITLE
Set minimum version of pyctdev 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
         - export PATH="$HOME/miniconda/bin:$PATH" && hash -r
         - conda config --set always_yes True
         # ...and now install doit/pyctdev into miniconda
-        - conda install -c pyviz pyctdev && doit ecosystem_setup
+        - conda install -c pyviz "pyctdev>=0.5" && doit ecosystem_setup
       install:
         - doit env_create $CHANS_DEV --python=$PYENV_VERSION
         - source activate test-environment


### PR DESCRIPTION
Avoids installation of much older version of pyctdev (behavior that started with conda 4.5.12, which was released 3 days ago; does not happen with 4.5.11).