### PR TITLE
Fix index-out-of-bounds line glyph crash and run select tests with JIT disabled

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,4 +19,4 @@ build: off
 
 test_script:
   - "doit test_all"
-  - "set NUMBA_DISABLE_JIT=1; doit test_unit_nojit"
+  - "set NUMBA_DISABLE_JIT=1 && doit test_unit_nojit & set NUMBA_DISABLE_JIT="

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,3 +19,4 @@ build: off
 
 test_script:
   - "doit test_all"
+  - "set NUMBA_DISABLE_JIT=1; doit test_unit_nojit"

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,9 @@ jobs:
         - source activate test-environment
         - doit develop_install $CHANS_DEV
         - doit env_capture
-      script: doit test_all
+      script:
+        - doit test_all
+        - export NUMBA_DISABLE_JIT=1; doit test_unit_nojit
 
     # python 2 flake checking typically catches python 2 syntax
     # errors where python 3's been assumed...

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -253,8 +253,18 @@ def _build_map_onto_pixel_for_line(x_mapper, y_mapper):
         xx = int(x_mapper(x) * sx + tx)
         yy = int(y_mapper(y) * sy + ty)
 
-        xxmax = int(x_mapper(xmax) * sx + tx)
-        yymax = int(y_mapper(ymax) * sy + ty)
+        # Note that sx and tx were designed so that
+        # x_mapper(xmax) * sx + tx equals the width of the canvas in pixels
+        #
+        # Likewise, sy and ty were designed so that
+        # y_mapper(ymax) * sy + ty equals the height of the canvas in pixels
+        #
+        # We round these results to integers (rather than casting to integers
+        # with the int constructor) to handle cases where floating-point
+        # precision errors results in a value just under the integer number
+        # of pixels.
+        xxmax = round(x_mapper(xmax) * sx + tx)
+        yymax = round(y_mapper(ymax) * sy + ty)
 
         return (xx - 1 if xx == xxmax else xx,
                 yy - 1 if yy == yymax else yy)

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -274,6 +274,46 @@ def test_line():
     assert_eq(agg, out)
 
 
+def test_points_on_edge():
+    df = pd.DataFrame(dict(x=[0, 0.5, 1.1, 1.5, 2.2, 3, 3, 0],
+                           y=[0, 0, 0, 0, 0, 0, 3, 3]))
+
+    canvas = ds.Canvas(plot_width=3, plot_height=3,
+                       x_range=(0, 3), y_range=(0, 3))
+
+    agg = canvas.points(df, 'x', 'y', agg=ds.count())
+
+    sol = np.array([[2, 2, 2],
+                    [0, 0, 0],
+                    [1, 0, 1]], dtype='int32')
+    out = xr.DataArray(sol,
+                       coords=[('x', [0.5, 1.5, 2.5]),
+                               ('y', [0.5, 1.5, 2.5])],
+                       dims=['y', 'x'])
+
+    assert_eq(agg, out)
+
+
+def test_lines_on_edge():
+    df = pd.DataFrame(dict(x=[0, 3, 3, 0],
+                           y=[0, 0, 3, 3]))
+
+    canvas = ds.Canvas(plot_width=3, plot_height=3,
+                       x_range=(0, 3), y_range=(0, 3))
+
+    agg = canvas.line(df, 'x', 'y', agg=ds.count())
+
+    sol = np.array([[1, 1, 1],
+                    [0, 0, 1],
+                    [1, 1, 1]], dtype='int32')
+    out = xr.DataArray(sol,
+                       coords=[('x', [0.5, 1.5, 2.5]),
+                               ('y', [0.5, 1.5, 2.5])],
+                       dims=['y', 'x'])
+
+    assert_eq(agg, out)
+
+
 def test_log_axis_line():
     axis = ds.core.LogAxis()
     logcoords = axis.compute_index(axis.compute_scale_and_translate((1, 10), 2), 2)

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -533,3 +533,23 @@ def test_trimesh_agg_api():
     cvs = ds.Canvas(x_range=(0, 10), y_range=(0, 10))
     agg = cvs.trimesh(pts, tris, agg=ds.mean('weight'))
     assert agg.shape == (600, 600)
+
+
+def test_bug_570():
+    # See https://github.com/pyviz/datashader/issues/570
+    df = pd.DataFrame({
+        'Time': [1456353642.2053893, 1456353642.2917893],
+        'data': [-59.4948743433377, 506.4847376716022],
+    }, columns=['Time', 'data'])
+
+    x_range = (1456323293.9859753, 1456374687.0009754)
+    y_range = (-228.56721300380943, 460.4042291124646)
+
+    cvs = ds.Canvas(x_range=x_range, y_range=y_range,
+                    plot_height=300, plot_width=1000)
+    agg = cvs.line(df, 'Time', 'data', agg=ds.count())
+
+    # Check location of line
+    yi, xi = np.where(agg.values == 1)
+    assert np.array_equal(yi, np.arange(73, 300))
+    assert np.array_equal(xi, np.array([590] * len(yi)))

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 #          python version                     test group            extra envs  extra commands       
-envlist = {py27,py35,py36}-{lint,unit,examples,all,examples_extra}-{default}-{dev,pkg}
+envlist = {py27,py35,py36}-{lint,unit,unit_nojit,examples,all,examples_extra}-{default}-{dev,pkg}
 build = wheel
 
 [_lint]
@@ -51,12 +51,14 @@ changedir = {envtmpdir}
 
 commands = pkg: {[_pkg]commands}
            unit: {[_unit]commands}
+           unit_nojit: {[_unit_nojit]commands}
            lint: {[_lint]commands}
            examples: {[_examples]commands}
            examples_extra: {[_examples_extra]commands}     
            all: {[_all]commands}
 
 deps = unit: {[_unit]deps}
+       unit_nojit: {[_unit_nojit]deps}
        lint: {[_lint]deps}
        examples: {[_examples]deps}
        examples_extra: {[_examples_extra]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 #          python version                     test group            extra envs  extra commands       
-envlist = {py27,py35,py36}-{lint,unit,examples,all,examples_extra}-{default}-{dev,pkg}
+envlist = {py27,py35,py36}-{lint,unit,unit_nojit,examples,all,examples_extra}-{default}-{dev,pkg}
 build = wheel
 
 [_lint]
@@ -18,6 +18,13 @@ commands = flake8
 description = Run unit tests
 deps = .[tests]
 commands = pytest datashader
+
+[_unit_nojit]
+description = Run select unit tests with numba jit disabled
+deps = .[tests]
+commands = export NUMBA_DISABLE_JIT=1
+           pytest datashader -k "not benchmarks and not test_tiles"
+           unset NUMBA_DISABLE_JIT
 
 [_examples]
 description = Test that default examples run
@@ -35,6 +42,7 @@ description = Run all tests (but only including default examples)
 deps = .[examples, tests]
 commands = {[_lint]commands}
            {[_unit]commands}
+           {[_unit_nojit]commands}
            {[_examples]commands}
 
 [_pkg]
@@ -46,12 +54,14 @@ changedir = {envtmpdir}
 
 commands = pkg: {[_pkg]commands}
            unit: {[_unit]commands}
+           unit_nojit: {[_unit_nojit]commands}
            lint: {[_lint]commands}
            examples: {[_examples]commands}
            examples_extra: {[_examples_extra]commands}     
            all: {[_all]commands}
 
 deps = unit: {[_unit]deps}
+       unit_nojit: {[_unit_nojit]deps}
        lint: {[_lint]deps}
        examples: {[_examples]deps}
        examples_extra: {[_examples_extra]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 
 [tox]
 #          python version                     test group            extra envs  extra commands       
-envlist = {py27,py35,py36}-{lint,unit,unit_nojit,examples,all,examples_extra}-{default}-{dev,pkg}
+envlist = {py27,py35,py36}-{lint,unit,examples,all,examples_extra}-{default}-{dev,pkg}
 build = wheel
 
 [_lint]
@@ -22,9 +22,7 @@ commands = pytest datashader
 [_unit_nojit]
 description = Run select unit tests with numba jit disabled
 deps = .[tests]
-commands = export NUMBA_DISABLE_JIT=1
-           pytest datashader -k "not benchmarks and not test_tiles"
-           unset NUMBA_DISABLE_JIT
+commands = pytest datashader -k "not benchmarks and not test_tiles"
 
 [_examples]
 description = Test that default examples run
@@ -42,7 +40,6 @@ description = Run all tests (but only including default examples)
 deps = .[examples, tests]
 commands = {[_lint]commands}
            {[_unit]commands}
-           {[_unit_nojit]commands}
            {[_examples]commands}
 
 [_pkg]
@@ -54,14 +51,12 @@ changedir = {envtmpdir}
 
 commands = pkg: {[_pkg]commands}
            unit: {[_unit]commands}
-           unit_nojit: {[_unit_nojit]commands}
            lint: {[_lint]commands}
            examples: {[_examples]commands}
            examples_extra: {[_examples_extra]commands}     
            all: {[_all]commands}
 
 deps = unit: {[_unit]deps}
-       unit_nojit: {[_unit_nojit]deps}
        lint: {[_lint]deps}
        examples: {[_examples]deps}
        examples_extra: {[_examples_extra]deps}


### PR DESCRIPTION
This PR closes #570 and #646 

Based on the helpful debugging of @bardiche98 and @p3trus, I was able to construct a small test case that reproduces the conditions of the crash reported in #570 (See 
4f7ae29  and the `test_bug_570` test in `datashader/tests/test_pandas.py`).

As discussed in #570, this did turn out to be an index-out-of-bounds error.  But since numba JIT-compiled code does not perform array bounds checking, this resulted in a non-deterministic kernel crash.

To more reliably reproduce and diagnose the issue, I made a few small changes to allow Datashader to operate with the numba jit compilation disabled (See ae920da).

I also added a new tox test configuration to run a subset of the Datashader unit tests with JIT compilation disabled (See 4219fba).  With JIT compilation disabled (and without the fix described below), `test_bug_570` reliably raises an `IndexError` and does not crash the kernel.

Finally, I actually fixed #570 in 105d766 by changing `int` to `round` in this section of the line glyph's `map_onto_pixel` function:

```python
        # Note that sx and tx were designed so that
        # x_mapper(xmax) * sx + tx equals the width of the canvas in pixels
        #
        # Likewise, sy and ty were designed so that
        # y_mapper(ymax) * sy + ty equals the height of the canvas in pixels
        #
        # We round these results to integers (rather than casting to integers
        # with the int constructor) to handle cases where floating-point
        # precision errors results in a value just under the integer number
        # of pixels.
        xxmax = round(x_mapper(xmax) * sx + tx)
        yymax = round(y_mapper(ymax) * sy + ty)
```

In this particular test case, the canvas is 300 pixels in height, so we want `yymax` to end up as 300.  But due to numerical precision subtleties `y_mapper(ymax) * sy + ty == 299.99999999999994` and so `int(y_mapper(ymax) * sy + ty) == 299` and `yymax` gets set to 299. By changing this to `round`, `yymax` ends up as 300 as it should.

~**Note:** Waiting on https://github.com/pyviz/datashader/pull/682 for travis test fixes~