### PR TITLE
Support for row-oriented coordinates in Canvas.line

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,6 +9,7 @@ environment:
 
 install:
   - "SET PATH=%CONDA%;%CONDA%\\Scripts;%PATH%"
+  - conda install -y "conda<4.6"
   - "conda install -y -c pyviz pyctdev && doit ecosystem_setup"
   - "doit env_create %CHANNELS% --name=test --python=%PY%"
   - "activate test"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,8 @@ environment:
 
 install:
   - "SET PATH=%CONDA%;%CONDA%\\Scripts;%PATH%"
-  - conda install -y -c pyviz pyctdev "conda<4.6" && doit ecosystem_setup
+  - "conda install -y -c pyviz pyctdev && doit ecosystem_setup"
+  - conda install -y "conda<4.6"
   - "doit env_create %CHANNELS% --name=test --python=%PY%"
   - "activate test"
   - "doit develop_install %CHANNELS%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,8 +9,7 @@ environment:
 
 install:
   - "SET PATH=%CONDA%;%CONDA%\\Scripts;%PATH%"
-  - conda install -y "conda<4.6"
-  - "conda install -y -c pyviz pyctdev && doit ecosystem_setup"
+  - conda install -y -c pyviz pyctdev "conda<4.6" && doit ecosystem_setup
   - "doit env_create %CHANNELS% --name=test --python=%PY%"
   - "activate test"
   - "doit develop_install %CHANNELS%"

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -187,6 +187,45 @@ class Canvas(object):
             agg = any_rdn()
         return bypixel(source, self, Line(x, y), agg)
 
+    def lines(self, source, x, y, agg=None,
+              x_constant=None, y_constant=None):
+        """Compute a reduction by pixel, mapping each row of source to pixels
+        in a distinct line
+
+        Parameters
+        ----------
+        source : pandas.DataFrame, dask.DataFrame, or xarray.DataArray/Dataset
+            The input datasource.
+        x, y: str or list
+            The x and y coordinates defining the line segments. Either xs and
+            ys are both strings or both lists.
+                * str: The name of a RaggedArray column in source that
+                       contains the x or y coordinates of the line segments.
+                * list: A list of the names of float or integer
+                               columns that contains the x or y coordinates of
+                               the line segment
+        agg : Reduction, optional
+            Reduction to compute. Default is ``any()``.
+        x_constant, y_constant: list or array of numbers
+            If xs is set to a list of column labels then y_constants may be
+            set to a list of numbers the same length as xs. These y
+            coordinates will be applied to every row.  Similarly, if ys is
+            a list of column labels, x_constants may be set to a list of
+            numbers to specify the x coordinates to be applied to every line
+            segment.
+
+            Exactly one of xs and x_constants may be specified and exactly
+            one of ys and y_constants may be specified.
+        """
+        from .glyphs import LinesXY
+        from .reductions import any as any_rdn
+        if agg is None:
+            agg = any_rdn()
+        return bypixel(source,
+                       self,
+                       LinesXY(tuple(x), tuple(y)),
+                       agg)
+
     # TODO re 'untested', below: Consider replacing with e.g. a 3x3
     # array in the call to Canvas (plot_height=3,plot_width=3), then
     # show the output as a numpy array that has a compact

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -541,10 +541,9 @@ def bypixel(source, canvas, glyph, agg):
 
 def _cols_to_keep(columns, glyph, agg):
     cols_to_keep = OrderedDict({col: False for col in columns})
-    cols_to_keep[glyph.x] = True
-    cols_to_keep[glyph.y] = True
-    if hasattr(glyph, 'z'):
-        cols_to_keep[glyph.z[0]] = True
+    for col in glyph.required_columns():
+        cols_to_keep[col] = True
+
     if hasattr(agg, 'values'):
         for subagg in agg.values:
             if subagg.column is not None:

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -187,8 +187,7 @@ class Canvas(object):
             agg = any_rdn()
         return bypixel(source, self, Line(x, y), agg)
 
-    def lines(self, source, x, y, agg=None,
-              x_constant=None, y_constant=None):
+    def lines(self, source, x, y, agg=None):
         """Compute a reduction by pixel, mapping each row of source to pixels
         in a distinct line
 
@@ -196,26 +195,11 @@ class Canvas(object):
         ----------
         source : pandas.DataFrame, dask.DataFrame, or xarray.DataArray/Dataset
             The input datasource.
-        x, y: str or list
-            The x and y coordinates defining the line segments. Either xs and
-            ys are both strings or both lists.
-                * str: The name of a RaggedArray column in source that
-                       contains the x or y coordinates of the line segments.
-                * list: A list of the names of float or integer
-                               columns that contains the x or y coordinates of
-                               the line segment
+        x, y: list
+            A list of the names of float or integer columns that contains
+            the x or y coordinates of the line segment
         agg : Reduction, optional
             Reduction to compute. Default is ``any()``.
-        x_constant, y_constant: list or array of numbers
-            If xs is set to a list of column labels then y_constants may be
-            set to a list of numbers the same length as xs. These y
-            coordinates will be applied to every row.  Similarly, if ys is
-            a list of column labels, x_constants may be set to a list of
-            numbers to specify the x coordinates to be applied to every line
-            segment.
-
-            Exactly one of xs and x_constants may be specified and exactly
-            one of ys and y_constants may be specified.
         """
         from .glyphs import LinesXY
         from .reductions import any as any_rdn

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -197,13 +197,13 @@ class Canvas(object):
 
         Examples
         --------
-        Define a canvas and a pandas DataFrame with N rows
-        >>> import pandas as pd
-        >>> import numpy as np
-        >>> from datashader import Canvas
-        >>> import datashader.transfer_functions as tf
-        >>> cvs = Canvas()
-        >>> df = pd.DataFrame({
+        Define a canvas and a pandas DataFrame with 6 rows
+        >>> import pandas as pd  # doctest: +SKIP
+        ... import numpy as np
+        ... from datashader import Canvas
+        ... import datashader.transfer_functions as tf
+        ... cvs = Canvas()
+        ... df = pd.DataFrame({
         ...    'A1': [1, 1.5, 2, 2.5, 3, 4],
         ...    'A2': [1.5, 2, 3, 3.2, 4, 5],
         ...    'B1': [10, 12, 11, 14, 13, 15],
@@ -211,33 +211,33 @@ class Canvas(object):
         ... }, dtype='float64')
 
         Aggregate one line across all rows, with coordinates df.A1 by df.B1
-        >>> agg = cvs.line(df, x='A1', y='B1', axis=0)
-        >>> tf.shade(agg)
+        >>> agg = cvs.line(df, x='A1', y='B1', axis=0)  # doctest: +SKIP
+        ... tf.shade(agg)
 
         Aggregate two lines across all rows. The first with coordinates
         df.A1 by df.B1 and the second with coordinates df.A2 by df.B2
-        >>> agg = cvs.line(df, x=['A1', 'A2'], y=['B1', 'B2'], axis=0)
-        >>> tf.shade(agg)
+        >>> agg = cvs.line(df, x=['A1', 'A2'], y=['B1', 'B2'], axis=0)  # doctest: +SKIP
+        ... tf.shade(agg)
 
         Aggregate two lines across all rows where the lines share the same
         x coordinates. The first line will have coordinates df.A1 by df.B1
         and the second will have coordinates df.A1 by df.B2
-        >>> agg = cvs.line(df, x='A1', y=['B1', 'B2'], axis=0)
-        >>> tf.shade(agg)
+        >>> agg = cvs.line(df, x='A1', y=['B1', 'B2'], axis=0)  # doctest: +SKIP
+        ... tf.shade(agg)
 
         Aggregate 6 length-2 lines, one per row, where the ith line has
         coordinates [df.A1[i], df.A2[i]] by [df.B1[i], df.B2[i]]
-        >>> agg = cvs.line(df, x=['A1', 'A2'], y=['B1', 'B2'], axis=1)
-        >>> tf.shade(agg)
+        >>> agg = cvs.line(df, x=['A1', 'A2'], y=['B1', 'B2'], axis=1)  # doctest: +SKIP
+        ... tf.shade(agg)
 
         Aggregate 6 length-4 lines, one per row, where the x coordinates
         of every line are [0, 1, 2, 3] and the y coordinates of the ith line
         are [df.A1[i], df.A2[i], df.B1[i], df.B2[i]].
-        >>> agg = cvs.line(df,
+        >>> agg = cvs.line(df,  # doctest: +SKIP
         ...                x=np.arange(4),
         ...                y=['A1', 'A2', 'B1', 'B2'],
         ...                axis=1)
-        >>> tf.shade(agg)
+        ... tf.shade(agg)
         """
         from .glyphs import (LineAxis0, LinesAxis1, LinesAxis1XConstant,
                              LinesAxis1YConstant, LineAxis0Multi)

--- a/datashader/dask.py
+++ b/datashader/dask.py
@@ -75,7 +75,7 @@ def default(glyph, df, schema, canvas, summary):
     keys2 = [(name, i) for i in range(len(keys))]
     dsk = dict((k2, (chunk, k)) for (k2, k) in zip(keys2, keys))
     dsk[name] = (apply, finalize, [(combine, keys2)],
-                 dict(coords=axis, dims=[glyph.y, glyph.x]))
+                 dict(coords=axis, dims=[glyph.y_label, glyph.x_label]))
     return dsk, name
 
 
@@ -106,5 +106,5 @@ def line(glyph, df, schema, canvas, summary):
         dsk[(name, i)] = (chunk, (old_name, i - 1), (old_name, i))
     keys2 = [(name, i) for i in range(df.npartitions)]
     dsk[name] = (apply, finalize, [(combine, keys2)],
-                 dict(coords=axis, dims=[glyph.y, glyph.x]))
+                 dict(coords=axis, dims=[glyph.y_label, glyph.x_label]))
     return dsk, name

--- a/datashader/dask.py
+++ b/datashader/dask.py
@@ -8,7 +8,7 @@ from dask.base import tokenize, compute
 from .core import bypixel
 from .compatibility import apply
 from .compiler import compile_components
-from .glyphs import Glyph, Line
+from .glyphs import Glyph, LineAxis0
 from .utils import Dispatcher
 
 __all__ = ()
@@ -79,7 +79,7 @@ def default(glyph, df, schema, canvas, summary):
     return dsk, name
 
 
-@glyph_dispatch.register(Line)
+@glyph_dispatch.register(LineAxis0)
 def line(glyph, df, schema, canvas, summary):
     shape, bounds, st, axis = shape_bounds_st_and_axis(df, canvas, glyph)
 

--- a/datashader/dask.py
+++ b/datashader/dask.py
@@ -31,8 +31,8 @@ def dask_pipeline(df, schema, canvas, glyph, summary):
 
 
 def shape_bounds_st_and_axis(df, canvas, glyph):
-    x_range = canvas.x_range or glyph._compute_x_bounds_dask(df)
-    y_range = canvas.y_range or glyph._compute_y_bounds_dask(df)
+    x_range = canvas.x_range or glyph.compute_x_bounds_dask(df)
+    y_range = canvas.y_range or glyph.compute_y_bounds_dask(df)
     x_min, x_max, y_min, y_max = bounds = compute(*(x_range + y_range))
     x_range, y_range = (x_min, x_max), (y_min, y_max)
 

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -234,9 +234,12 @@ class Line(_PointLike):
 
 
 class LinesXY(_PointLike):
+
     def validate(self, in_dshape):
-        # TODO
-        pass
+        if not all([isreal(in_dshape.measure[xcol]) for xcol in self.x]):
+            raise ValueError('x columns must be real')
+        elif not all([isreal(in_dshape.measure[ycol]) for ycol in self.y]):
+            raise ValueError('y columns must be real')
 
     def required_columns(self):
         return self.x + self.y

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -234,7 +234,14 @@ class Line(_PointLike):
 
 
 class LinesXY(_PointLike):
+    """A collection of lines (on line per row) with vertices defined
+    by the lists of columns in ``x`` and ``y``
 
+    Parameters
+    ----------
+    x, y : list
+        Lists of column names for the x and y coordinates
+    """
     def validate(self, in_dshape):
         if not all([isreal(in_dshape.measure[xcol]) for xcol in self.x]):
             raise ValueError('x columns must be real')
@@ -283,10 +290,8 @@ class LinesXY(_PointLike):
         minval, maxval = np.nanmin(x_mins), np.nanmax(x_maxes)
 
         if minval == np.nan and maxval == np.nan:
-            # print("No x values; defaulting to range -1,1")
             minval, maxval = -1, 1
         elif minval == maxval:
-            # print("No x range; defaulting to x-1,x+1")
             minval, maxval = minval - 1, minval + 1
         return minval, maxval
 
@@ -301,10 +306,8 @@ class LinesXY(_PointLike):
         minval, maxval = np.nanmin(y_mins), np.nanmax(y_maxes)
 
         if minval == np.nan and maxval == np.nan:
-            # print("No x values; defaulting to range -1,1")
             minval, maxval = -1, 1
         elif minval == maxval:
-            # print("No x range; defaulting to x-1,x+1")
             minval, maxval = minval - 1, minval + 1
         return minval, maxval
 

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -17,6 +17,10 @@ class _PointLike(Glyph):
         self.x = x
         self.y = y
 
+    def __hash__(self):
+        return hash(
+            tuple([self.__class__, self.x, self.y]))
+
     @property
     def inputs(self):
         return (self.x, self.y)
@@ -135,6 +139,11 @@ class _PolygonLike(_PointLike):
             self.z = z
         self.interpolate = interp
         self.weight_type = weight_type
+
+    def __hash__(self):
+        return hash(
+            tuple([self.__class__, self.x, self.y, tuple(self.z),
+                   self.interpolate, self.weight_type]))
 
     @property
     def inputs(self):

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -253,7 +253,7 @@ class LinesAxis1(_PointLike):
     """
 
     def __init__(self, x, y):
-        super(_PointLike, self).__init__(tuple(x), tuple(y))
+        super(LinesAxis1, self).__init__(tuple(x), tuple(y))
 
     def validate(self, in_dshape):
         if not all([isreal(in_dshape.measure[xcol]) for xcol in self.x]):

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -297,7 +297,7 @@ class LinesXY(_PointLike):
 
     @memoize
     def compute_y_bounds_dask(self, df):
-        """Like ``PointLike._compute_x_bounds``, but memoized because
+        """Like ``PointLike.compute_x_bounds``, but memoized because
         ``df`` is immutable/hashable (a Dask dataframe).
         """
         y_mins = [np.nanmin(df[ylabel].values) for ylabel in self.y]

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -273,6 +273,42 @@ class LinesXY(_PointLike):
         return y_min, y_max
 
     @memoize
+    def compute_x_bounds_dask(self, df):
+        """Like ``PointLike._compute_x_bounds``, but memoized because
+        ``df`` is immutable/hashable (a Dask dataframe).
+        """
+        x_mins = [np.nanmin(df[xlabel].values) for xlabel in self.x]
+        x_maxes = [np.nanmax(df[xlabel].values) for xlabel in self.x]
+
+        minval, maxval = np.nanmin(x_mins), np.nanmax(x_maxes)
+
+        if minval == np.nan and maxval == np.nan:
+            # print("No x values; defaulting to range -1,1")
+            minval, maxval = -1, 1
+        elif minval == maxval:
+            # print("No x range; defaulting to x-1,x+1")
+            minval, maxval = minval - 1, minval + 1
+        return minval, maxval
+
+    @memoize
+    def compute_y_bounds_dask(self, df):
+        """Like ``PointLike._compute_x_bounds``, but memoized because
+        ``df`` is immutable/hashable (a Dask dataframe).
+        """
+        y_mins = [np.nanmin(df[ylabel].values) for ylabel in self.y]
+        y_maxes = [np.nanmax(df[ylabel].values) for ylabel in self.y]
+
+        minval, maxval = np.nanmin(y_mins), np.nanmax(y_maxes)
+
+        if minval == np.nan and maxval == np.nan:
+            # print("No x values; defaulting to range -1,1")
+            minval, maxval = -1, 1
+        elif minval == maxval:
+            # print("No x range; defaulting to x-1,x+1")
+            minval, maxval = minval - 1, minval + 1
+        return minval, maxval
+
+    @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
         draw_line = _build_draw_line(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -216,7 +216,7 @@ class Point(_PointLike):
         return extend
 
 
-class Line(_PointLike):
+class LineAxis0(_PointLike):
     """A line, with vertices defined by ``x`` and ``y``.
 
     Parameters
@@ -242,7 +242,7 @@ class Line(_PointLike):
         return extend
 
 
-class LinesXY(_PointLike):
+class LinesAxis1(_PointLike):
     """A collection of lines (on line per row) with vertices defined
     by the lists of columns in ``x`` and ``y``
 
@@ -251,6 +251,10 @@ class LinesXY(_PointLike):
     x, y : list
         Lists of column names for the x and y coordinates
     """
+
+    def __init__(self, x, y):
+        super().__init__(tuple(x), tuple(y))
+
     def validate(self, in_dshape):
         if not all([isreal(in_dshape.measure[xcol]) for xcol in self.x]):
             raise ValueError('x columns must be real')

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -27,6 +27,9 @@ class _PointLike(Glyph):
         elif not isreal(in_dshape.measure[self.y]):
             raise ValueError('y must be real')
 
+    def required_columns(self):
+        return [self.x, self.y]
+
     def compute_x_bounds(self, df):
         return self._compute_x_bounds(df[self.x].values)
 
@@ -88,7 +91,6 @@ class _PointLike(Glyph):
             #print("No x range; defaulting to x-1,x+1")
             minval, maxval = minval-1, minval+1
         return minval, maxval
-        
 
     @memoize
     def compute_y_bounds_dask(self, df):
@@ -134,6 +136,9 @@ class _PolygonLike(_PointLike):
         for col in [self.x, self.y] + list(self.z):
             if not isreal(in_dshape.measure[col]):
                 raise ValueError('{} must be real'.format(col))
+
+    def required_columns(self):
+        return [self.x, self.y] + list(self.z)
 
     def compute_x_bounds(self, df):
         xs = df[self.x].values

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -281,7 +281,7 @@ class LinesXY(_PointLike):
 
     @memoize
     def compute_x_bounds_dask(self, df):
-        """Like ``PointLike._compute_x_bounds``, but memoized because
+        """Like ``PointLike.compute_x_bounds``, but memoized because
         ``df`` is immutable/hashable (a Dask dataframe).
         """
         x_mins = [np.nanmin(df[xlabel].values) for xlabel in self.x]

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -253,7 +253,7 @@ class LinesAxis1(_PointLike):
     """
 
     def __init__(self, x, y):
-        super().__init__(tuple(x), tuple(y))
+        super(_PointLike, self).__init__(tuple(x), tuple(y))
 
     def validate(self, in_dshape):
         if not all([isreal(in_dshape.measure[xcol]) for xcol in self.x]):

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -27,6 +27,12 @@ class _PointLike(Glyph):
         elif not isreal(in_dshape.measure[self.y]):
             raise ValueError('y must be real')
 
+    def compute_x_bounds(self, df):
+        return self._compute_x_bounds(df[self.x].values)
+
+    def compute_y_bounds(self, df):
+        return self._compute_y_bounds(df[self.y].values)
+
     @staticmethod
     @ngjit
     def _compute_x_bounds(xs):
@@ -68,7 +74,7 @@ class _PointLike(Glyph):
         return minval, maxval
 
     @memoize
-    def _compute_x_bounds_dask(self, df):
+    def compute_x_bounds_dask(self, df):
         """Like ``PointLike._compute_x_bounds``, but memoized because
         ``df`` is immutable/hashable (a Dask dataframe).
         """
@@ -85,7 +91,7 @@ class _PointLike(Glyph):
         
 
     @memoize
-    def _compute_y_bounds_dask(self, df):
+    def compute_y_bounds_dask(self, df):
         """Like ``PointLike._compute_y_bounds``, but memoized because
         ``df`` is immutable/hashable (a Dask dataframe).
         """
@@ -128,6 +134,14 @@ class _PolygonLike(_PointLike):
         for col in [self.x, self.y] + list(self.z):
             if not isreal(in_dshape.measure[col]):
                 raise ValueError('{} must be real'.format(col))
+
+    def compute_x_bounds(self, df):
+        xs = df[self.x].values
+        return self._compute_x_bounds(xs.reshape(np.prod(xs.shape)))
+
+    def compute_y_bounds(self, df):
+        ys = df[self.y].values
+        return self._compute_y_bounds(ys.reshape(np.prod(ys.shape)))
 
 
 class Point(_PointLike):

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -250,12 +250,24 @@ class LinesXY(_PointLike):
         return 'y'
 
     def compute_x_bounds(self, df):
-        # return self._compute_x_bounds(df[self.x].values)
-        raise NotImplementedError()
+        xs = tuple(df[xlabel] for xlabel in self.x)
+
+        x_bounds_list = [self._compute_x_bounds(xcol.values) for xcol in xs]
+        x_mins, x_maxes = zip(*x_bounds_list)
+
+        x_min = min(x_mins)
+        x_max = max(x_maxes)
+        return x_min, x_max
 
     def compute_y_bounds(self, df):
-        # return self._compute_y_bounds(df[self.y].values)
-        raise NotImplementedError()
+        ys = tuple(df[ylabel] for ylabel in self.y)
+
+        y_bounds_list = [self._compute_y_bounds(ycol.values) for ycol in ys]
+        y_mins, y_maxes = zip(*y_bounds_list)
+
+        y_min = min(y_mins)
+        y_max = max(y_maxes)
+        return y_min, y_max
 
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -233,8 +233,10 @@ class Triangles(_PolygonLike):
         draw_triangle, draw_triangle_interp = _build_draw_triangle(append)
         map_onto_pixel = _build_map_onto_pixel_for_triangle(x_mapper, y_mapper)
         extend_triangles = _build_extend_triangles(draw_triangle, draw_triangle_interp, map_onto_pixel)
+        weight_type = self.weight_type
+        interpolate = self.interpolate
 
-        def extend(aggs, df, vt, bounds, weight_type=True, interpolate=True):
+        def extend(aggs, df, vt, bounds, plot_start=True):
             cols = info(df)
             assert cols, 'There must be at least one column on which to aggregate'
             # mapped to pixels, then may be clipped

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -573,7 +573,6 @@ def _build_extend_line(draw_line, map_onto_pixel):
 
 
 def _build_extend_lines_xy(draw_line, map_onto_pixel):
-    extend_line = _build_extend_line(draw_line, map_onto_pixel)
 
     @ngjit
     def extend_lines_xy(vt, bounds, xs, ys, plot_start, *aggs_and_cols):

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -22,9 +22,9 @@ class _PointLike(Glyph):
         return (self.x, self.y)
 
     def validate(self, in_dshape):
-        if not isreal(in_dshape.measure[self.x]):
+        if not isreal(in_dshape.measure[str(self.x)]):
             raise ValueError('x must be real')
-        elif not isreal(in_dshape.measure[self.y]):
+        elif not isreal(in_dshape.measure[str(self.y)]):
             raise ValueError('y must be real')
 
     @property
@@ -127,7 +127,7 @@ class _PolygonLike(_PointLike):
 
     def validate(self, in_dshape):
         for col in [self.x, self.y] + list(self.z):
-            if not isreal(in_dshape.measure[col]):
+            if not isreal(in_dshape.measure[str(col)]):
                 raise ValueError('{} must be real'.format(col))
 
     def required_columns(self):
@@ -225,9 +225,9 @@ class LineAxis0Multi(_PointLike):
     """
 
     def validate(self, in_dshape):
-        if not all([isreal(in_dshape.measure[xcol]) for xcol in self.x]):
+        if not all([isreal(in_dshape.measure[str(xcol)]) for xcol in self.x]):
             raise ValueError('x columns must be real')
-        elif not all([isreal(in_dshape.measure[ycol]) for ycol in self.y]):
+        elif not all([isreal(in_dshape.measure[str(ycol)]) for ycol in self.y]):
             raise ValueError('y columns must be real')
 
     @property

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -254,6 +254,20 @@ class LineAxis0Multi(_PointLike):
         return self.maybe_expand_bounds((min(mins), max(maxes)))
 
     @memoize
+    def compute_x_bounds_dask(self, df):
+        bounds_list = [self._compute_x_bounds(df[x].values.compute())
+                       for x in self.x]
+        mins, maxes = zip(*bounds_list)
+        return self.maybe_expand_bounds((min(mins), max(maxes)))
+
+    @memoize
+    def compute_y_bounds_dask(self, df):
+        bounds_list = [self._compute_y_bounds(df[y].values.compute())
+                       for y in self.y]
+        mins, maxes = zip(*bounds_list)
+        return self.maybe_expand_bounds((min(mins), max(maxes)))
+
+    @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
         draw_line = _build_draw_line(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)

--- a/datashader/pandas.py
+++ b/datashader/pandas.py
@@ -41,4 +41,6 @@ def pointlike(glyph, df, schema, canvas, summary):
     bases = create((height, width))
     extend(bases, df, x_st + y_st, x_range + y_range)
 
-    return finalize(bases, coords=[y_axis, x_axis], dims=[glyph.y, glyph.x])
+    return finalize(bases,
+                    coords=[y_axis, x_axis],
+                    dims=[glyph.y_label, glyph.x_label])

--- a/datashader/pandas.py
+++ b/datashader/pandas.py
@@ -1,11 +1,10 @@
 from __future__ import absolute_import, division
 
-import numpy as np
 import pandas as pd
 
 from .core import bypixel
 from .compiler import compile_components
-from .glyphs import _PointLike, _PolygonLike
+from .glyphs import _PointLike
 from .utils import Dispatcher
 
 __all__ = ()

--- a/datashader/pandas.py
+++ b/datashader/pandas.py
@@ -26,8 +26,8 @@ def pointlike(glyph, df, schema, canvas, summary):
     y_mapper = canvas.y_axis.mapper
     extend = glyph._build_extend(x_mapper, y_mapper, info, append)
 
-    x_range = canvas.x_range or glyph._compute_x_bounds(df[glyph.x].values)
-    y_range = canvas.y_range or glyph._compute_y_bounds(df[glyph.y].values)
+    x_range = canvas.x_range or glyph.compute_x_bounds(df)
+    y_range = canvas.y_range or glyph.compute_y_bounds(df)
 
     width = canvas.plot_width
     height = canvas.plot_height

--- a/datashader/pandas.py
+++ b/datashader/pandas.py
@@ -42,31 +42,3 @@ def pointlike(glyph, df, schema, canvas, summary):
     extend(bases, df, x_st + y_st, x_range + y_range)
 
     return finalize(bases, coords=[y_axis, x_axis], dims=[glyph.y, glyph.x])
-
-
-
-@glyph_dispatch.register(_PolygonLike)
-def polygonlike(glyph, df, schema, canvas, summary):
-    create, info, append, _, finalize = compile_components(summary, schema, glyph)
-    x_mapper = canvas.x_axis.mapper
-    y_mapper = canvas.y_axis.mapper
-    extend = glyph._build_extend(x_mapper, y_mapper, info, append)
-
-    xs = df[glyph.x].values
-    x_range = canvas.x_range or glyph._compute_x_bounds(xs.reshape(np.prod(xs.shape)))
-    ys = df[glyph.y].values
-    y_range = canvas.y_range or glyph._compute_y_bounds(ys.reshape(np.prod(ys.shape)))
-
-    width = canvas.plot_width
-    height = canvas.plot_height
-
-    x_st = canvas.x_axis.compute_scale_and_translate(x_range, width)
-    y_st = canvas.y_axis.compute_scale_and_translate(y_range, height)
-
-    x_axis = canvas.x_axis.compute_index(x_st, width)
-    y_axis = canvas.y_axis.compute_index(y_st, height)
-
-    bases = create((height, width))
-    extend(bases, df, x_st + y_st, x_range + y_range, weight_type=glyph.weight_type, interpolate=glyph.interpolate)
-
-    return finalize(bases, coords=[y_axis, x_axis], dims=[glyph.y, glyph.x])

--- a/datashader/tests/benchmarks/test_extend_line.py
+++ b/datashader/tests/benchmarks/test_extend_line.py
@@ -2,7 +2,7 @@ import pytest
 
 import numpy as np
 
-from datashader.glyphs import _build_draw_line, _build_extend_line, _build_map_onto_pixel_for_line
+from datashader.glyphs import _build_draw_line, _build_extend_line_axis0, _build_map_onto_pixel_for_line
 from datashader.utils import ngjit
 
 
@@ -15,7 +15,7 @@ def extend_line():
     mapper = ngjit(lambda x: x)
     map_onto_pixel = _build_map_onto_pixel_for_line(mapper, mapper)
     draw_line = _build_draw_line(append)
-    return _build_extend_line(draw_line, map_onto_pixel)
+    return _build_extend_line_axis0(draw_line, map_onto_pixel)
 
 
 @pytest.mark.parametrize('high', [0, 10**5])

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -300,10 +300,11 @@ def test_lines_xy():
     cvs = ds.Canvas(plot_width=7, plot_height=7,
                     x_range=(-3, 3), y_range=(-3, 3))
 
-    agg = cvs.lines(ddf,
-                    ['x0', 'x1', 'x2'],
-                    ['y0', 'y1', 'y2'],
-                    ds.count())
+    agg = cvs.line(ddf,
+                   ['x0', 'x1', 'x2'],
+                   ['y0', 'y1', 'y2'],
+                   ds.count(),
+                   axis=1)
 
     sol = np.array([[0, 0, 1, 0, 1, 0, 0],
                     [0, 1, 0, 0, 0, 1, 0],
@@ -336,10 +337,11 @@ def test_lines_xy_autorange():
 
     cvs = ds.Canvas(plot_width=9, plot_height=9)
 
-    agg = cvs.lines(ddf,
-                    ['x0', 'x1', 'x2'],
-                    ['y0', 'y1', 'y2'],
-                    ds.count())
+    agg = cvs.line(ddf,
+                   ['x0', 'x1', 'x2'],
+                   ['y0', 'y1', 'y2'],
+                   ds.count(),
+                   axis=1)
 
     sol = np.array([[0, 0, 0, 0, 1, 0, 0, 0, 0],
                     [0, 0, 0, 1, 0, 1, 0, 0, 0],

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -282,6 +282,80 @@ def test_line():
     assert_eq(agg, out)
 
 
+def test_lines_xy():
+    axis = ds.core.LinearAxis()
+    lincoords = axis.compute_index(axis.compute_scale_and_translate((-3., 3.), 7), 7)
+
+    df = pd.DataFrame({
+        'x0': [4, -4, 4],
+        'x1': [0,  0, 0],
+        'x2': [-4, 4, -4],
+        'y0': [0,  0, 0],
+        'y1': [-4, 4, 0],
+        'y2': [0,  0, 0]
+    })
+
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    cvs = ds.Canvas(plot_width=7, plot_height=7,
+                    x_range=(-3, 3), y_range=(-3, 3))
+
+    agg = cvs.lines(ddf,
+                    ['x0', 'x1', 'x2'],
+                    ['y0', 'y1', 'y2'],
+                    ds.count())
+
+    sol = np.array([[0, 0, 1, 0, 1, 0, 0],
+                    [0, 1, 0, 0, 0, 1, 0],
+                    [1, 0, 0, 0, 0, 0, 1],
+                    [1, 1, 1, 1, 1, 1, 1],
+                    [1, 0, 0, 0, 0, 0, 1],
+                    [0, 1, 0, 0, 0, 1, 0],
+                    [0, 0, 1, 0, 1, 0, 0]], dtype='i4')
+
+    out = xr.DataArray(sol, coords=[lincoords, lincoords],
+                       dims=['y', 'x'])
+    assert_eq(agg, out)
+
+
+def test_lines_xy_autorange():
+    axis = ds.core.LinearAxis()
+    lincoords = axis.compute_index(
+        axis.compute_scale_and_translate((-4., 4.), 9), 9)
+
+    df = pd.DataFrame({
+        'x0': [4, -4, 4],
+        'x1': [0, 0, 0],
+        'x2': [-4, 4, -4],
+        'y0': [0, 0, 0],
+        'y1': [-4, 4, 0],
+        'y2': [0, 0, 0]
+    })
+
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    cvs = ds.Canvas(plot_width=9, plot_height=9)
+
+    agg = cvs.lines(ddf,
+                    ['x0', 'x1', 'x2'],
+                    ['y0', 'y1', 'y2'],
+                    ds.count())
+
+    sol = np.array([[0, 0, 0, 0, 1, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 1, 0, 0, 0],
+                    [0, 0, 1, 0, 0, 0, 1, 0, 0],
+                    [0, 1, 0, 0, 0, 0, 0, 1, 0],
+                    [3, 1, 1, 1, 1, 1, 1, 1, 3],
+                    [0, 1, 0, 0, 0, 0, 0, 1, 0],
+                    [0, 0, 1, 0, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 1, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 1, 0, 0, 0, 0]], dtype='i4')
+
+    out = xr.DataArray(sol, coords=[lincoords, lincoords],
+                       dims=['y', 'x'])
+    assert_eq(agg, out)
+
+
 def test_log_axis_line():
     axis = ds.core.LogAxis()
     logcoords = axis.compute_index(axis.compute_scale_and_translate((1, 10), 2), 2)

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -5,7 +5,7 @@ import pytest
 
 from datashader.glyphs import (Point, _build_draw_line,
                                _build_map_onto_pixel_for_line,
-                               _build_extend_line, _build_draw_triangle,
+                               _build_extend_line_axis0, _build_draw_triangle,
                                _build_map_onto_pixel_for_triangle,
                                _build_extend_triangles, LinesAxis1)
 from datashader.utils import ngjit
@@ -44,7 +44,7 @@ map_onto_pixel_for_triangle = _build_map_onto_pixel_for_triangle(mapper, mapper)
 
 # Line rasterization
 draw_line = _build_draw_line(append)
-extend_line = _build_extend_line(draw_line, map_onto_pixel_for_line)
+extend_line = _build_extend_line_axis0(draw_line, map_onto_pixel_for_line)
 
 # Triangles rasterization
 draw_triangle, draw_triangle_interp = _build_draw_triangle(tri_append)
@@ -370,7 +370,7 @@ def test_line_awkward_point_on_upper_bound_maps_to_last_pixel():
 def test_lines_xy_validate():
     g = LinesAxis1(['x0', 'x1'], ['y11', 'y12'])
     g.validate(
-        dshape("{x0: int32, x1: float32, y11: int16, y12: float32}"))
+        dshape("{x0: int32, x1: int32, y11: float32, y12: float32}"))
 
     with pytest.raises(ValueError):
         g.validate(

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -7,7 +7,7 @@ from datashader.glyphs import (Point, _build_draw_line,
                                _build_map_onto_pixel_for_line,
                                _build_extend_line, _build_draw_triangle,
                                _build_map_onto_pixel_for_triangle,
-                               _build_extend_triangles, LinesXY)
+                               _build_extend_triangles, LinesAxis1)
 from datashader.utils import ngjit
 
 
@@ -368,7 +368,7 @@ def test_line_awkward_point_on_upper_bound_maps_to_last_pixel():
 
 
 def test_lines_xy_validate():
-    g = LinesXY(['x0', 'x1'], ['y11', 'y12'])
+    g = LinesAxis1(['x0', 'x1'], ['y11', 'y12'])
     g.validate(
         dshape("{x0: int32, x1: float32, y11: int16, y12: float32}"))
 

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -3,9 +3,11 @@ import pandas as pd
 import numpy as np
 import pytest
 
-from datashader.glyphs import (Point, _build_draw_line, _build_map_onto_pixel_for_line,
+from datashader.glyphs import (Point, _build_draw_line,
+                               _build_map_onto_pixel_for_line,
                                _build_extend_line, _build_draw_triangle,
-                               _build_map_onto_pixel_for_triangle, _build_extend_triangles)
+                               _build_map_onto_pixel_for_triangle,
+                               _build_extend_triangles, LinesXY)
 from datashader.utils import ngjit
 
 
@@ -363,3 +365,13 @@ def test_line_awkward_point_on_upper_bound_maps_to_last_pixel():
                                       1.0, y)
 
     assert pymax==num_y_pixels-1
+
+
+def test_lines_xy_validate():
+    g = LinesXY(['x0', 'x1'], ['y11', 'y12'])
+    g.validate(
+        dshape("{x0: int32, x1: float32, y11: int16, y12: float32}"))
+
+    with pytest.raises(ValueError):
+        g.validate(
+            dshape("{x0: int32, x1: float32, y11: string, y12: float32}"))

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -611,10 +611,11 @@ def test_lines_xy():
     cvs = ds.Canvas(plot_width=7, plot_height=7,
                     x_range=(-3, 3), y_range=(-3, 3))
 
-    agg = cvs.lines(df,
-                    ['x0', 'x1', 'x2'],
-                    ['y0', 'y1', 'y2'],
-                    ds.count())
+    agg = cvs.line(df,
+                   ['x0', 'x1', 'x2'],
+                   ['y0', 'y1', 'y2'],
+                   ds.count(),
+                   axis=1)
 
     sol = np.array([[0, 0, 1, 0, 1, 0, 0],
                     [0, 1, 0, 0, 0, 1, 0],
@@ -645,10 +646,11 @@ def test_lines_xy_autorange():
 
     cvs = ds.Canvas(plot_width=9, plot_height=9)
 
-    agg = cvs.lines(df,
-                    ['x0', 'x1', 'x2'],
-                    ['y0', 'y1', 'y2'],
-                    ds.count())
+    agg = cvs.line(df,
+                   ['x0', 'x1', 'x2'],
+                   ['y0', 'y1', 'y2'],
+                   ds.count(),
+                   axis=1)
 
     sol = np.array([[0, 0, 0, 0, 1, 0, 0, 0, 0],
                     [0, 0, 0, 1, 0, 1, 0, 0, 0],

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -627,3 +627,39 @@ def test_lines_xy():
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
     assert_eq(agg, out)
+
+
+def test_lines_xy_autorange():
+    axis = ds.core.LinearAxis()
+    lincoords = axis.compute_index(
+        axis.compute_scale_and_translate((-4., 4.), 9), 9)
+
+    df = pd.DataFrame({
+        'x0': [4, -4],
+        'x1': [0,  0],
+        'x2': [-4, 4],
+        'y0': [0,  0],
+        'y1': [-4, 4],
+        'y2': [0,  0]
+    })
+
+    cvs = ds.Canvas(plot_width=9, plot_height=9)
+
+    agg = cvs.lines(df,
+                    ['x0', 'x1', 'x2'],
+                    ['y0', 'y1', 'y2'],
+                    ds.count())
+
+    sol = np.array([[0, 0, 0, 0, 1, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 1, 0, 0, 0],
+                    [0, 0, 1, 0, 0, 0, 1, 0, 0],
+                    [0, 1, 0, 0, 0, 0, 0, 1, 0],
+                    [2, 0, 0, 0, 0, 0, 0, 0, 2],
+                    [0, 1, 0, 0, 0, 0, 0, 1, 0],
+                    [0, 0, 1, 0, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 1, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 1, 0, 0, 0, 0]], dtype='i4')
+
+    out = xr.DataArray(sol, coords=[lincoords, lincoords],
+                       dims=['y', 'x'])
+    assert_eq(agg, out)

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -595,27 +595,67 @@ def test_bug_570():
     assert np.array_equal(xi, np.array([590] * len(yi)))
 
 
-def test_lines_xy():
-    axis = ds.core.LinearAxis()
-    lincoords = axis.compute_index(axis.compute_scale_and_translate((-3., 3.), 7), 7)
-
-    df = pd.DataFrame({
+# # Line tests
+@pytest.mark.parametrize('df,x,y,ax', [
+    # axis1 none constant
+    (pd.DataFrame({
         'x0': [4, -4],
         'x1': [0,  0],
         'x2': [-4, 4],
         'y0': [0,  0],
         'y1': [-4, 4],
         'y2': [0,  0]
-    })
+    }), ['x0', 'x1', 'x2'], ['y0', 'y1', 'y2'], 1),
+
+    # axis1 x constant
+    (pd.DataFrame({
+        'y0': [0,  0],
+        'y1': [-4, 4],
+        'y2': [0,  0]
+    }), np.array([-4, 0, 4]), ['y0', 'y1', 'y2'], 1),
+
+    # axis1 y constant
+    (pd.DataFrame({
+        'x0': [0, 0],
+        'x1': [-4, 4],
+        'x2': [0, 0]
+    }), ['x0', 'x1', 'x2'], np.array([-4, 0, 4]), 1),
+
+    # axis0 single
+    (pd.DataFrame({
+        'x': [0, -4, 0, np.nan, 0,  4, 0],
+        'y': [-4, 0, 4, np.nan, -4, 0, 4],
+    }), 'x', 'y', 0),
+
+    # axis0 multi
+    (pd.DataFrame({
+        'x0': [0, -4, 0],
+        'x1': [0,  4, 0],
+        'y0': [-4, 0, 4],
+        'y1': [-4, 0, 4],
+    }), ['x0', 'x1'], ['y0', 'y1'], 0),
+
+    # axis0 multi with string
+    (pd.DataFrame({
+        'x0': [0, -4, 0],
+        'x1': [0,  4, 0],
+        'y0': [-4, 0, 4],
+        'y1': [-4, 0, 4],
+    }), ['x0', 'x1'], 'y0', 0),
+])
+def test_line_manual_range(df, x, y, ax):
+    axis = ds.core.LinearAxis()
+    lincoords = axis.compute_index(
+        axis.compute_scale_and_translate((-3., 3.), 7), 7)
 
     cvs = ds.Canvas(plot_width=7, plot_height=7,
                     x_range=(-3, 3), y_range=(-3, 3))
 
     agg = cvs.line(df,
-                   ['x0', 'x1', 'x2'],
-                   ['y0', 'y1', 'y2'],
+                   x,
+                   y,
                    ds.count(),
-                   axis=1)
+                   axis=ax)
 
     sol = np.array([[0, 0, 1, 0, 1, 0, 0],
                     [0, 1, 0, 0, 0, 1, 0],
@@ -630,15 +670,81 @@ def test_lines_xy():
     assert_eq(agg, out)
 
 
-def test_lines_xy_autorange():
+@pytest.mark.parametrize('df,x,y,ax', [
+    # axis1 none constant
+    (pd.DataFrame({
+        'x0': [0,  0],
+        'x1': [-4, 4],
+        'x2': [0,  0],
+        'y0': [-4, -4],
+        'y1': [0,  0],
+        'y2': [4,  4]
+    }), ['x0', 'x1', 'x2'], ['y0', 'y1', 'y2'], 1),
+
+    # axis1 y constant
+    (pd.DataFrame({
+        'x0': [0, 0],
+        'x1': [-4, 4],
+        'x2': [0, 0]
+    }), ['x0', 'x1', 'x2'], np.array([-4, 0, 4]), 1),
+
+    # axis0 single
+    (pd.DataFrame({
+        'x': [0, -4, 0, np.nan, 0,  4, 0],
+        'y': [-4, 0, 4, np.nan, -4, 0, 4],
+    }), 'x', 'y', 0),
+
+    # axis0 multi
+    (pd.DataFrame({
+        'x0': [0, -4, 0],
+        'x1': [0,  4, 0],
+        'y0': [-4, 0, 4],
+        'y1': [-4, 0, 4],
+    }), ['x0', 'x1'], ['y0', 'y1'], 0),
+
+    # axis0 multi with string
+    (pd.DataFrame({
+        'x0': [0, -4, 0],
+        'x1': [0,  4, 0],
+        'y0': [-4, 0, 4],
+        'y1': [-4, 0, 4],
+    }), ['x0', 'x1'], 'y0', 0),
+])
+def test_line_autorange(df, x, y, ax):
     axis = ds.core.LinearAxis()
     lincoords = axis.compute_index(
         axis.compute_scale_and_translate((-4., 4.), 9), 9)
 
+    cvs = ds.Canvas(plot_width=9, plot_height=9)
+
+    agg = cvs.line(df,
+                   x,
+                   y,
+                   ds.count(),
+                   axis=ax)
+
+    sol = np.array([[0, 0, 0, 0, 2, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 1, 0, 0, 0],
+                    [0, 0, 1, 0, 0, 0, 1, 0, 0],
+                    [0, 1, 0, 0, 0, 0, 0, 1, 0],
+                    [1, 0, 0, 0, 0, 0, 0, 0, 1],
+                    [0, 1, 0, 0, 0, 0, 0, 1, 0],
+                    [0, 0, 1, 0, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 1, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 2, 0, 0, 0, 0]], dtype='i4')
+
+    out = xr.DataArray(sol, coords=[lincoords, lincoords],
+                       dims=['y', 'x'])
+    assert_eq(agg, out)
+
+
+def test_line_autorange_axis1_x_constant():
+    axis = ds.core.LinearAxis()
+    lincoords = axis.compute_index(
+        axis.compute_scale_and_translate((-4., 4.), 9), 9)
+
+    xs = np.array([-4, 0, 4])
     df = pd.DataFrame({
-        'x0': [4, -4],
-        'x1': [0,  0],
-        'x2': [-4, 4],
         'y0': [0,  0],
         'y1': [-4, 4],
         'y2': [0,  0]
@@ -647,7 +753,7 @@ def test_lines_xy_autorange():
     cvs = ds.Canvas(plot_width=9, plot_height=9)
 
     agg = cvs.line(df,
-                   ['x0', 'x1', 'x2'],
+                   xs,
                    ['y0', 'y1', 'y2'],
                    ds.count(),
                    axis=1)
@@ -661,6 +767,43 @@ def test_lines_xy_autorange():
                     [0, 0, 1, 0, 0, 0, 1, 0, 0],
                     [0, 0, 0, 1, 0, 1, 0, 0, 0],
                     [0, 0, 0, 0, 1, 0, 0, 0, 0]], dtype='i4')
+
+    out = xr.DataArray(sol, coords=[lincoords, lincoords],
+                       dims=['y', 'x'])
+    assert_eq(agg, out)
+
+
+# Sum aggregate
+def test_line_agg_sum_axis1_none_constant():
+    axis = ds.core.LinearAxis()
+    lincoords = axis.compute_index(axis.compute_scale_and_translate((-3., 3.), 7), 7)
+
+    df = pd.DataFrame({
+        'x0': [4, -4],
+        'x1': [0,  0],
+        'x2': [-4, 4],
+        'y0': [0,  0],
+        'y1': [-4, 4],
+        'y2': [0,  0],
+        'v': [7, 9]
+    })
+
+    cvs = ds.Canvas(plot_width=7, plot_height=7,
+                    x_range=(-3, 3), y_range=(-3, 3))
+
+    agg = cvs.line(df,
+                   ['x0', 'x1', 'x2'],
+                   ['y0', 'y1', 'y2'],
+                   ds.sum('v'),
+                   axis=1)
+    nan = np.nan
+    sol = np.array([[nan, nan, 7,   nan, 7,   nan, nan],
+                    [nan, 7,   nan, nan, nan, 7,   nan],
+                    [7,   nan, nan, nan, nan, nan, 7],
+                    [nan, nan, nan, nan, nan, nan, nan],
+                    [9,   nan, nan, nan, nan, nan, 9],
+                    [nan, 9,   nan, nan, nan, 9,   nan],
+                    [nan, nan, 9,   nan, 9,   nan, nan]], dtype='float32')
 
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -593,3 +593,37 @@ def test_bug_570():
     yi, xi = np.where(agg.values == 1)
     assert np.array_equal(yi, np.arange(73, 300))
     assert np.array_equal(xi, np.array([590] * len(yi)))
+
+
+def test_lines_xy():
+    axis = ds.core.LinearAxis()
+    lincoords = axis.compute_index(axis.compute_scale_and_translate((-3., 3.), 7), 7)
+
+    df = pd.DataFrame({
+        'x0': [4, -4],
+        'x1': [0,  0],
+        'x2': [-4, 4],
+        'y0': [0,  0],
+        'y1': [-4, 4],
+        'y2': [0,  0]
+    })
+
+    cvs = ds.Canvas(plot_width=7, plot_height=7,
+                    x_range=(-3, 3), y_range=(-3, 3))
+
+    agg = cvs.lines(df,
+                    ['x0', 'x1', 'x2'],
+                    ['y0', 'y1', 'y2'],
+                    ds.count())
+
+    sol = np.array([[0, 0, 1, 0, 1, 0, 0],
+                    [0, 1, 0, 0, 0, 1, 0],
+                    [1, 0, 0, 0, 0, 0, 1],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [1, 0, 0, 0, 0, 0, 1],
+                    [0, 1, 0, 0, 0, 1, 0],
+                    [0, 0, 1, 0, 1, 0, 0]], dtype='i4')
+
+    out = xr.DataArray(sol, coords=[lincoords, lincoords],
+                       dims=['y', 'x'])
+    assert_eq(agg, out)

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -23,13 +23,30 @@ class Expr(object):
     defines that expression.
     """
     def __hash__(self):
-        return hash((type(self), self.inputs))
+        return hash((type(self), self._hashable_inputs()))
 
     def __eq__(self, other):
-        return type(self) is type(other) and self.inputs == other.inputs
+        return (type(self) is type(other) and
+                self._hashable_inputs() == other._hashable_inputs())
 
     def __ne__(self, other):
         return not self == other
+
+    def _hashable_inputs(self):
+        """
+        Return a version of the inputs tuple that is suitable for hashing and
+        equality comparisons
+        """
+        result = []
+        for ip in self.inputs:
+            if isinstance(ip, (list, set)):
+                result.append(tuple(ip))
+            elif isinstance(ip, np.ndarray):
+                result.append(ip.tobytes())
+            else:
+                result.append(ip)
+
+        return tuple(result)
 
 
 class Dispatcher(object):

--- a/examples/user_guide/3_Timeseries.ipynb
+++ b/examples/user_guide/3_Timeseries.ipynb
@@ -387,11 +387,11 @@
     "\n",
     "The examples above all used a small number of very long time series, which is one important use case for Datashader.  Another important use case is visualizing very large numbers of time series, even if each individual curve is relatively short. If you have hundreds of thousands of timeseries, putting each one into a Pandas dataframe column and aggregating it individually will not be very efficient. \n",
     "\n",
-    "Luckily, Datashader can render arbitrarily many separate curves, limited only by what you can fit into a Dask dataframe (which in turn is limited only by your system's total disk storage). Instead of having a dataframe with one column per curve, you would instead use a single column for 'x' and one for 'y', with an extra row containing a NaN value to separate each curve from its neighbor (so that no line will connect between them). In this way you can plot millions or billions of curves efficiently.\n",
+    "Luckily, Datashader can render arbitrarily many separate curves, limited only by what you can fit into a Dask dataframe (which in turn is limited only by your system's total disk storage). Instead of having a dataframe where each pair of columns (one for `x` one for `y`) represents a curve, you can have a dataframe where each row represents a fixed-length curve.  In this case, the `x` and `y` arguments should be set to lists of the labels of the columns that represent the curve coordinates and the `axis` argument should be set to 1.  If all of the lines share the same coordiantes for one of the dimensions, then the corresponding argument (either `x` or `y`) can be replaced with a 1-dimensional numpy array containing these coordinates.\n",
     "\n",
-    "To make it simpler to construct such a dataframe for the special case of having multiple time series of the same length, Datashader includes a utility function accepting a 2D Numpy array and returning a NaN-separated dataframe. (See [datashader issue 286](https://github.com/bokeh/datashader/issues/286#issuecomment-334619499) for background.) \n",
+    "In this way you can plot millions or billions of fixed length curves efficiently.\n",
     "\n",
-    "As an example, let's generate 100,000 sequences, each with 10 points, as a Numpy array:"
+    "As an example, let's generate a Numpy array containing 100,000 sequences with 10 points each, where each sequence represents a 1-dimensional random walk with step size drawn from the standard normal distribution:"
    ]
   },
   {
@@ -402,7 +402,8 @@
    "source": [
     "n = 100000\n",
     "points = 10\n",
-    "data = np.random.normal(0, 100, size = (n, points))\n",
+    "time = np.linspace(0, 1, points)\n",
+    "data = np.cumsum(np.random.randn(n, points) , axis=1)\n",
     "data.shape"
    ]
   },
@@ -410,7 +411,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can create a suitable Datashader-compatible tidy dataframe using the utility:"
+    "We can create a pandas dataframe from this numpy array directly, where each row in the resulting dataframe represents an independent trial of the random walk:"
    ]
   },
   {
@@ -419,7 +420,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = ds.utils.dataframe_from_multiple_sequences(np.arange(points), data)\n",
+    "df = pd.DataFrame(data)\n",
     "df.head(15)"
    ]
   },
@@ -427,7 +428,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And then render it as usual:"
+    "To render these lines we set the `x` argument to `time` (the 1-dimensional numpy array containing the shared x-coordinates) the `y` argument to `list(range(points))` (a list of the column labels of `df` the contain the y-coordinates of each line), and the `axis` argument to `1` (indicating that each row of the dataframe represents a line rather than each pair of columns)."
    ]
   },
   {
@@ -437,7 +438,7 @@
    "outputs": [],
    "source": [
     "cvs = ds.Canvas(plot_height=400, plot_width=1000)\n",
-    "agg = cvs.line(df, 'x', 'y', ds.count())   \n",
+    "agg = cvs.line(df, x=time, y=list(range(points)), agg=ds.count(), axis=1)\n",
     "img = tf.shade(agg, how='eq_hist')\n",
     "img"
    ]
@@ -446,7 +447,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here, the 10 high and low peaks each represent one of the 10 values in each sequence, with lines connecting those random values to the next one in the sequence.  Thanks to the `eq-hist` colorization, you can see subtle differences in the likelihood of any particular pixel being crossed by these line segments, with the values towards the middle of each gap most heavily crossed as you would expect.  You'll see a similar plot for 1,000,000 or 10,000,000 curves, and much more interesting plots if you have real data to show!"
+    "Here, each line represents an independent trial of this random walk process.  At time 0 (all the way to the left) the lines are positioned according to the standard normal distribution. At each time step, each line moves upward or downward from it's prior position by a distance drawn from the standard normal distribution.  Thanks to the `eq-hist` colorization, you can see the dispersion in the density of the overall distribution as time advances.  You can also see the individual outliers at the extremes of the distribution.  You'll see a similar plot for 1,000,000 or 10,000,000 curves, and much more interesting plots if you have real data to show!"
    ]
   }
  ],

--- a/examples/user_guide/3_Timeseries.ipynb
+++ b/examples/user_guide/3_Timeseries.ipynb
@@ -387,11 +387,11 @@
     "\n",
     "The examples above all used a small number of very long time series, which is one important use case for Datashader.  Another important use case is visualizing very large numbers of time series, even if each individual curve is relatively short. If you have hundreds of thousands of timeseries, putting each one into a Pandas dataframe column and aggregating it individually will not be very efficient. \n",
     "\n",
-    "Luckily, Datashader can render arbitrarily many separate curves, limited only by what you can fit into a Dask dataframe (which in turn is limited only by your system's total disk storage). Instead of having a dataframe where each pair of columns (one for `x` one for `y`) represents a curve, you can have a dataframe where each row represents a fixed-length curve.  In this case, the `x` and `y` arguments should be set to lists of the labels of the columns that represent the curve coordinates and the `axis` argument should be set to 1.  If all of the lines share the same coordiantes for one of the dimensions, then the corresponding argument (either `x` or `y`) can be replaced with a 1-dimensional numpy array containing these coordinates.\n",
+    "Luckily, Datashader can render arbitrarily many separate curves, limited only by what you can fit into a Dask dataframe (which in turn is limited only by your system's total disk storage). Instead of having a dataframe where each pair of columns (one for `x` one for `y`) represents a curve, you can have a dataframe where each row represents a fixed-length curve.  In this case, the `x` and `y` arguments should be set to lists of the labels of the columns that represent the curve coordinates and the `axis` argument should be set to 1.  If all of the lines share the same coordinates for one of the dimensions, then the corresponding argument (either `x` or `y`) can be replaced with a 1-dimensional NumPy array containing these coordinates.\n",
     "\n",
-    "In this way you can plot millions or billions of fixed length curves efficiently.\n",
+    "In this way you can plot millions or billions of fixed-length curves efficiently.\n",
     "\n",
-    "As an example, let's generate a Numpy array containing 100,000 sequences with 10 points each, where each sequence represents a 1-dimensional random walk with step size drawn from the standard normal distribution:"
+    "As an example, let's generate a NumPy array containing 100,000 sequences with 10 points each, where each sequence represents a 1-dimensional random walk with step size drawn from the standard normal distribution:"
    ]
   },
   {
@@ -403,7 +403,7 @@
     "n = 100000\n",
     "points = 10\n",
     "time = np.linspace(0, 1, points)\n",
-    "data = np.cumsum(np.random.randn(n, points) , axis=1)\n",
+    "data = np.cumsum(np.c_[np.zeros((n,1)), np.random.randn(n, points)] , axis=1)\n",
     "data.shape"
    ]
   },
@@ -411,7 +411,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can create a pandas dataframe from this numpy array directly, where each row in the resulting dataframe represents an independent trial of the random walk:"
+    "We can create a Pandas dataframe from this NumPy array directly, where each row in the resulting dataframe represents an independent trial of the random walk:"
    ]
   },
   {
@@ -428,7 +428,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To render these lines we set the `x` argument to `time` (the 1-dimensional numpy array containing the shared x-coordinates) the `y` argument to `list(range(points))` (a list of the column labels of `df` the contain the y-coordinates of each line), and the `axis` argument to `1` (indicating that each row of the dataframe represents a line rather than each pair of columns)."
+    "To render these lines we set the `x` argument to `time` (the 1-dimensional NumPy array containing the shared x coordinates) the `y` argument to `list(range(points))` (a list of the column labels of `df` the contain the y coordinates of each line), and the `axis` argument to `1` (indicating that each row of the dataframe represents a line rather than each pair of columns)."
    ]
   },
   {
@@ -447,7 +447,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here, each line represents an independent trial of this random walk process.  At time 0 (all the way to the left) the lines are positioned according to the standard normal distribution. At each time step, each line moves upward or downward from it's prior position by a distance drawn from the standard normal distribution.  Thanks to the `eq-hist` colorization, you can see the dispersion in the density of the overall distribution as time advances.  You can also see the individual outliers at the extremes of the distribution.  You'll see a similar plot for 1,000,000 or 10,000,000 curves, and much more interesting plots if you have real data to show!"
+    "Here, each line represents an independent trial of this random walk process.  All lines start from the same point at time 0 (all the way to the left). At each subsquent time step, each line moves upward or downward from its prior position by a distance drawn from a normal distribution.  Thanks to the nonlinear `eq-hist` colorization, you can see the dispersion in the density of the overall distribution as time advances, at the same time as you can see the individual outliers at the extremes of the distribution.  You'll see a similar plot for 1,000,000 or 10,000,000 curves, and much more interesting plots if you have real data to show!"
    ]
   }
  ],


### PR DESCRIPTION
## Overview
This PR introduces a new `Canvas.lines` method for rendering collections of polylines (here called "lines" for short) where each polyline corresponds to a single row in an input DataFrame.  This is in contrast to the current `Canvas.line` method which renders a single polyline (potentially containing gaps if there are nan values) per DataFrame.

I propose that this method eventually be overloaded to support the following 3 use-cases. Note: This PR only implements (1), but I'm hopeful that the addition of (2) and (3) will not require much additional refactoring.

 1. Each line has the same length, `N`, and is represented by `N` columns containing the x coordinates and `N` columns containing the y coordinates.  Here's an example in the case of two-vertex line segments (N=2):
```python
cvs.lines(df, x=['x0', 'x1'], y=['y0', 'y1'])
```

2. Each line has the same length, `N`, but either the x or y vertex coordinates are constant for all lines.  A common use-case here would be time-series data, where the x values (the time bins) are constant across all lines and each row of the DataFrame contains only the y-coordinates of each line. This would nicely handle cases like the one brought up in https://github.com/pyviz/datashader/issues/286#issuecomment-281896685, without the need to concatenate and nan separate each line.  Here's what the aggregation step for this example could look like:

```python
data = ... # 10000 x 50 array representing 10000 lines over 50 time bins
cvs.lines(pd.DataFrame(data), y=list(range(50)), x_constants=np.linspace(0, 10, 50))
```

Note that the `data` numpy array is converted into a DataFrame before being passed to `cvs.lines`.  This DataFrame will have columns with integer labels that match the column index, and so the `y=list(range(50))` argument is specifying a list of the column labels where the column labels are integers.  As suggested in https://github.com/pyviz/datashader/issues/283, it would also be nice to allow DataShader to accept a numpy (or Dask) array directly without requiring this DataFrame conversion step.  I see this as a somewhat orthogonal feature that would require support across several other parts of the API.

3. Each line may have a different length.  In this case the x and y vertex coordinates could be stored in a pair of RaggedArray columns (https://github.com/pyviz/datashader/pull/687).  

**Additional consideration:**  For cases 1 and 2, we should also have a way to specify whether lines are
represented by rows (as I originally had in mind writing the descriptions above) or by columns.  Representing lines by rows is useful when the line lengths are manageable, but there are lots and lots of lines.  Specifying lines by columns is useful when the number of lines is manageable, but each line has lots and lots of points.

## Example
Drawing line segments

```python
import numpy as np
import pandas as pd
import dask.dataframe as dd
import datashader as ds
import datashader.utils as du, datashader.transfer_functions as tf

n = 100
np.random.seed(2)

x0 = np.random.uniform(size=n)
x1 = np.random.uniform(size=n)
y0 = np.random.uniform(size=n)
y1 = np.random.uniform(size=n)

pts = np.stack((x0,x1,y0,y1)).T
df = pd.DataFrame(np.stack((x0,x1,y0,y1)).T, columns=['x0', 'x1', 'y0', 'y1'])

cvs = ds.Canvas(plot_height=400,plot_width=400, x_range=[0, 1], y_range=[0, 1])
tf.shade(cvs.lines(df, ['x0', 'x1'], ['y0', 'y1'], agg=ds.count()))
```
![download](https://user-images.githubusercontent.com/15064365/51503649-2c83ed00-1daa-11e9-9eb7-64e64bf25ab0.png)

## Performance

**Edit:** See updated performance results in https://github.com/pyviz/datashader/pull/694#issuecomment-456607889

Here are some performance comparisons comparing `cvs.lines` with the equivalent `cvs.line` command for the segment example above. Timing does not take into account the time to generate the nan separated DataFrame needed by `cvs.line`.

![newplot 8](https://user-images.githubusercontent.com/15064365/51504248-f9435d00-1dad-11e9-9665-97a3254a0ed1.png)

And here's what scaling looks like on my quad-core 2015 MBP.
![newplot 9](https://user-images.githubusercontent.com/15064365/51504331-6a831000-1dae-11e9-9c1b-a847077e4a12.png)

So the current `cvs.line` approach is consistently a *little* bit faster in the single-threaded case. But if the conversion time were taken into account this difference would probably get washed out.  And for some reason the new `cvs.lines` approach seems to scale a little better in the multi-threaded case (at least for 3 and 4 cores).

## TODO
 - [x] Evaluate unifying this functionality with the current `cvs.line` method by adding a new "lines-by-rows-or-columns" argument.  Either way, sketch out the future API for the by-rows and by-columns cases.
 - [x] Rewrite last section of http://datashader.org/user_guide/3_Timeseries.html

