### PR TITLE
Add conda-forge as a channel in appveyor config

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   global:
-    CHANNELS: "-c pyviz/label/dev"
+    CHANNELS: "-c conda-forge -c pyviz/label/dev"
   matrix:
     - PY: "2.7"
       CONDA: "C:\\Miniconda-x64"


### PR DESCRIPTION
I am hoping that this will fix the test failures seen in https://ci.appveyor.com/project/pyviz/datashader/builds/21775593/job/cil60b72fh0cblbn for instance. The approach is based on this discussion: https://github.com/pyviz/datashader/issues/534