### PR TITLE
Initial Dask trimesh support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,6 @@ environment:
 install:
   - "SET PATH=%CONDA%;%CONDA%\\Scripts;%PATH%"
   - "conda install -y -c pyviz pyctdev && doit ecosystem_setup"
-  - conda install -y "conda<4.6"
   - "doit env_create %CHANNELS% --name=test --python=%PY%"
   - "activate test"
   - "doit develop_install %CHANNELS%"

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -123,7 +123,8 @@ class _PolygonLike(_PointLike):
 
     @property
     def inputs(self):
-        return tuple([self.x, self.y] + list(self.z))
+        return (tuple([self.x, self.y] + list(self.z)) +
+                (self.weight_type, self.interpolate))
 
     def validate(self, in_dshape):
         for col in [self.x, self.y] + list(self.z):

--- a/examples/user_guide/6_Trimesh.ipynb
+++ b/examples/user_guide/6_Trimesh.ipynb
@@ -47,6 +47,7 @@
     "import numpy as np, datashader as ds, pandas as pd\n",
     "import datashader.utils as du, datashader.transfer_functions as tf\n",
     "from scipy.spatial import Delaunay\n",
+    "import dask.dataframe as dd\n",
     "\n",
     "n = 10\n",
     "np.random.seed(2)\n",
@@ -343,6 +344,37 @@
     "tf.Images(tf.shade(cvs.trimesh(verts, tris, mesh=mesh, agg=ds.any('z')), name='any'),\n",
     "          tf.shade(cvs.trimesh(verts, tris, mesh=mesh, agg=ds.count()),  name='count'),\n",
     "          tf.shade(cvs.trimesh(verts, tris, mesh=mesh, agg=ds.std('z')), name='std')).cols(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Parallelizing trimesh aggregation with Dask\n",
+    "The trimesh aggregation process can be parallelized by providing `du.mesh` and `Canvas.trimesh` with partitioned Dask dataframes.\n",
+    "\n",
+    "**Note:** While the calls to `Canvas.trimesh` will be parallelized across the partitions of the Dask dataframe, the construction of the partitioned mesh using `du.mesh` is not currently parallelized.  Furthermore, it currently requires loading the entire `verts` and `tris` dataframes into memory in order to construct the partitioned mesh.  Because of these constraints, this approach is most useful for the repeated aggregation of large meshes that fit in memory on a single multicore machine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "verts_ddf = dd.from_pandas(verts, npartitions=4)\n",
+    "tris_ddf = dd.from_pandas(tris, npartitions=4)\n",
+    "mesh_ddf = du.mesh(verts_ddf, tris_ddf)\n",
+    "mesh_ddf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tf.shade(cvs.trimesh(verts_ddf, tris_ddf, mesh=mesh_ddf))"
    ]
   },
   {


### PR DESCRIPTION
## Overview
This PR provides initial support for parallel aggregation of trimesh glyphs using dask

**Note:** This PR is based on https://github.com/pyviz/datashader/pull/694 as it relies on some of the refactoring performed in that PR.

## Usage
To take advantage of dask trimesh support, the `datashader.utils.mesh` utility function should be called with dask `DataFrame`s for the the `vertices` and `simplices` arguments.  In this case, the resulting `mesh` DataFrame will be a dask DataFrame rather than a pandas DataFrame.

When this dask mesh is passed into the `cvs.trimesh` functino, the trimesh aggregations will be performing in parallel.  For example

```python
# Dask mesh
verts_ddf = dd.from_pandas(verts, npartitions=4)
tris_ddf = dd.from_pandas(pd.concat([tris]*copies, axis=0), npartitions=4)
mesh_ddf = du.mesh(verts_ddf, tris_ddf).persist()

cvs = ds.Canvas(plot_height=900, plot_width=900)
agg = cvs.trimesh(verts_ddf, tris_ddf, mesh_ddf)
```

## Implementation Notes
The job of the `du.mesh` function is to return a DataFrame containing the coordinates of every vertex in every triangle in the mesh in the proper winding order.  A triangle is represented in this data structure by three rows, one for each vertex.  If a single vertex is used by more then one triangle, then the coordinates of that vertex will show up in multiple rows in this DataFrame.

One important characteristic of the updated `du.mesh` function when called with a dask DataFrame is that it makes sure that no triangles straddle a partition boundary in the output.  This amounts to making sure that the number of rows in each partition is a multiple of 3.  The function attempts to build the output dask dataframe with the greater of the number of partitions in `vertices` and `simplices`, but the constraint to avoid breaking up triangles takes precedence over the number of partitions.

The speedup here is only in the call to `cvs.trimesh`, the call to `du.mesh` still requires pulling the `vertices` and `simplices` DataFrames into memory. Parallelizing this step in the calculation will take a bit more thought, and may require some spatial ordering of the input DataFrames.

## Bechmarking
I ran some benchmark tests comparing the pandas aggregation with this new dask aggregation.  These were run on a 2015 MBP with a quadcore processor. All of the dask tests were run using 4 partitions.

To scale the number of triangles I used the Chesapeake Bay mesh (https://github.com/pyviz/datashader/blob/master/examples/topics/bay_trimesh.ipynb), and then duplicated the simplices between 1 and 100 times.  This scales from ~1 million to ~100 million triangles.

**pandas vs dask runtime:**
![dask_pandas_time](https://user-images.githubusercontent.com/15064365/51683563-24010180-1fb8-11e9-8984-19b7bc441edb.png)

**dask speedup factor (pandas runtime / dask runtime)**
![dask_speedup_factor](https://user-images.githubusercontent.com/15064365/51683575-27948880-1fb8-11e9-8090-9460996c1f3b.png)

So the dask implementation is about 1.2 times faster on 1 million triangles and up the 4.3 times faster on 100 million triangles.

