### PR TITLE
Add SpatialPointsFrame class to support spatial partitioning for points aggregation

### DIFF
--- a/datashader/spatial/__init__.py
+++ b/datashader/spatial/__init__.py
@@ -525,7 +525,7 @@ SpatialPointsFrame.partition_and_write static method.""".format(
         -------
         x_bin_edges: np.ndarray
         """
-        return np.linspace(*self.x_range, self._side_length + 1)
+        return np.linspace(*self.x_range, num=self._side_length + 1)
 
     @property
     def y_bin_edges(self):
@@ -537,7 +537,7 @@ SpatialPointsFrame.partition_and_write static method.""".format(
         -------
         y_bin_edges: np.ndarray
         """
-        return np.linspace(*self.y_range, self._side_length + 1)
+        return np.linspace(*self.y_range, num=self._side_length + 1)
 
     @property
     def distance_divisions(self):

--- a/datashader/spatial/__init__.py
+++ b/datashader/spatial/__init__.py
@@ -1,0 +1,621 @@
+from __future__ import absolute_import
+import copy
+import os
+import shutil
+import json
+
+import numpy as np
+import pandas as pd
+import dask.dataframe as dd
+
+from datashader.spatial import hilbert_curve as hc
+try:
+    import fastparquet as fp
+except ImportError:
+    fp = None
+
+# Declare Python2/3 unicode-safe string type
+try:
+    basestring
+except NameError:
+    basestring = str
+
+
+def _data2coord(vals, val_range, side_length):
+    """
+    Convert an array of values from continuous data coordinates to discrete
+    Hilbert coordinates
+
+    Parameters
+    ----------
+    vals: list or tuple or np.ndarray
+        Array of continuous data coordinate to be converted to discrete
+        distance coordinates
+    val_range: tuple
+        Start (val_range[0]) and stop (val_range[1]) range in continuous
+        data coordinates
+    side_length: int
+        The number of discrete distance coordinates
+
+    Returns
+    -------
+    np.ndarray
+        Of discrete Hilbert coordinates
+    """
+    if isinstance(vals, (list, tuple)):
+        vals = np.array(vals)
+
+    x_width = val_range[1] - val_range[0]
+    return ((vals - val_range[0]) * (side_length / x_width)
+            ).astype(np.int64).clip(0, side_length - 1)
+
+
+def _compute_distance(df, x, y, p, x_range, y_range):
+    """
+    Compute an array of Hilbert distances from a pandas dataframe
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+        pandas dataframe containing the coordinate columns
+    x
+        Label of the column containing the x-coordinates
+    y
+        Label of the column containing the y-coordinates
+    p: int
+        Hilbert-curve p value
+    x_range: tuple
+        Start (x_range[0]) and stop (x_range[1]) range of Hilbert x
+        scale in data coordinates
+    y_range: tuple
+        Start (y_range[0]) and stop (y_range[1]) range of Hilbert y
+        scale in data coordinates
+
+    Returns
+    -------
+    np.ndarray
+        Of Hilbert distances
+    """
+    side_length = 2 ** p
+    x_coords = _data2coord(df[x], x_range, side_length)
+    y_coords = _data2coord(df[y], y_range, side_length)
+    return hc.distance_from_coordinates(p, x_coords, y_coords)
+
+
+def _compute_extents(df, x, y):
+    """
+    Compute the min and max for x and y columns in a pandas dataframe
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+    x
+        Label of column in df that contains the x values
+    y
+        Label of column in df that contains the y values
+
+    Returns
+    -------
+    pd.DataFrame
+        Single row dataframe containing x_min, x_max, y_min, and y_max columns
+    """
+    x_min = df[x].min()
+    x_max = df[x].max()
+    y_min = df[y].min()
+    y_max = df[y].max()
+    return pd.DataFrame({'x_min': x_min,
+                         'x_max': x_max,
+                         'y_min': y_min,
+                         'y_max': y_max},
+                        index=[0])
+
+
+def _validate_fastparquet():
+    """
+    Raise an informative error message if fastparquet is not installed
+    """
+    if fp is None:
+        raise ImportError("""\
+The datashader.spatial module requires the fastparquet package""")
+
+
+class SpatialPointsFrame(object):
+    """
+    Class that wraps a spatially partitioned parquet data set and provides
+    a query_partitions method to access the subset of partitions necessary to
+    cover the specified x/y range extents.
+
+    The spatially partitioned parquet data set must first be created using
+    the `SpatialPointsFrame.partition_and_write` static method. Instances
+    of the SpatialPointsFrame class can then be constructed with this
+    partitioned parquet data set.
+
+    Note that this class is only suitable for partitioning data sets for use
+    with the Canvas.points aggregation method.
+
+    Examples
+    --------
+    First, construct a spatially partitioned parquet file. This is an expensive
+    operation that only needs to be performed once for a data set.
+    >>> import numpy as np  # doctest: +SKIP
+    ... import pandas as pd
+    ... from datashader.spatial import SpatialPointsFrame
+    ...
+    ... N = 1000
+    ... df = pd.DataFrame({
+    ...     'x': np.random.rand(N),
+    ...     'y': np.random.rand(N) * 2,
+    ...     'a': np.random.randn(N)})
+    ...
+    ... filename = './spatial_points.parquet'
+    ... SpatialPointsFrame.partition_and_write(df, 'x', 'y', filename)
+
+    Then, construct a SpatialPointsFrame and use it to extract
+    subsets of the original dataframe based on x/y range extents.
+    >>> sframe = SpatialPointsFrame(filename, persist=True)
+    ...
+    ... def create_image(x_range, y_range):
+    ...     cvs = ds.Canvas(x_range=x_range, y_range=y_range)
+    ...     df = sframe.query_partitions(x_range, y_range)
+    ...     agg = cvs.points(df, 'x', 'y')
+    ...     return tf.dynspread(tf.shade(agg))
+    ...
+    ... create_image(x_range=(0, 0.3), y_range=(1, 1.5))
+    """
+
+    @staticmethod
+    def partition_and_write(df,
+                            x,
+                            y,
+                            filename,
+                            p=10,
+                            npartitions=None,
+                            shuffle=None,
+                            compression='default'):
+        """
+        Perform spatial partitioning on an input dataframe and write the
+        result to a parquet file.  The resulting parquet file will contain
+        the same columns as the input dataframe, but the dataframe's original
+        index will be dropped.
+
+        The resulting parquet file will contain all of the rows from the
+        input dataframe, but they will be spatially sorted and partitioned
+        along a 2D Hilbert curve (https://en.wikipedia.org/wiki/Hilbert_curve).
+
+        The parquet file will also contain custom metadata that is needed to
+        reconstruct the Hilbert curve distances on load.  This parquet file
+        may then be used to construct SpatialPointsFrame instances.
+
+        Parameters
+        ----------
+        df: pd.DataFrame or dd.DataFrame
+            The input dataframe to partition
+        x, y
+            The column labels in df of the x and y coordinates of each row
+        filename: str
+            The path where the resulting parquet file should be written.
+            See dask.dataframe.to_parquet for description of supported path
+            specifications.
+        p: int (default 10)
+            The Hilbert curve order parameter that determines the resolution
+            of the 2D grid that data points are rounded to before computing
+            their Hilbert distance. Points will be discretized into 2 ** p
+            bins in each the x and y dimensions.
+
+            This parameter should be increased if the partitions of the
+            resulting parquet files are significantly unbalanced.
+
+        npartitions: int or None (default None)
+            The number of partitions for the resulting parquet file.  If None
+            (the default) this is chosen to be the greater of 8 and
+            len(df) // 2**23.
+
+            In general, increasing the number of partitions will improve
+            performance when processing small subsets of the overall parquet
+            data set.  But this comes at the cost of some additional overhead
+            when processing the entire data set.
+
+        shuffle: str or None (default None)
+            The dask.dataframe.DataFrame.set_index shuffle method. If None,
+            a default is chosen based on the current scheduler.
+
+        compression: str or None (default)
+            The dask.dataframe.to_parquet compression method.
+        """
+
+        _validate_fastparquet()
+
+        # Validate filename
+        if (not isinstance(filename, basestring) or
+                not filename.endswith('.parquet')):
+            raise ValueError(
+                'filename must be a string ending with a .parquet extension')
+
+        # Remove any existing directory
+        if os.path.exists(filename):
+            shutil.rmtree(filename)
+
+        # Normalize to dask dataframe
+        if isinstance(df, pd.DataFrame):
+            ddf = dd.from_pandas(df, npartitions=4)
+        elif isinstance(df, dd.DataFrame):
+            ddf = df
+        else:
+            raise ValueError("""
+df must be a pandas or dask DataFrame instance.
+Received value of type {typ}""".format(typ=type(df)))
+
+        # Compute npartitions if needed
+        if npartitions is None:
+            # Make partitions of ~8 million rows with a minimum of 8
+            # partitions
+            npartitions = max(len(df) // 2**23, 8)
+
+        # Compute data extents
+        extents = ddf.map_partitions(
+            _compute_extents, x, y).compute()
+
+        x_range = (float(extents['x_min'].min()),
+                   float(extents['x_max'].max()))
+
+        y_range = (float(extents['y_min'].min()),
+                   float(extents['y_max'].max()))
+
+        # Compute distance of points along the Hilbert-curve
+        ddf = ddf.assign(distance=ddf.map_partitions(
+            _compute_distance, x=x, y=y, p=p,
+            x_range=x_range, y_range=y_range))
+
+        # Set index to distance. This will trigger an expensive shuffle
+        # sort operation
+        ddf = ddf.set_index('distance',
+                            npartitions=npartitions,
+                            shuffle=shuffle)
+
+        # Get list of the distance divisions computed by dask
+        distance_divisions = [int(d) for d in ddf.divisions]
+
+        # Save properties as custom metadata in the parquet file
+        props = dict(
+            version='1.0',
+            x=x,
+            y=y,
+            p=p,
+            distance_divisions=distance_divisions,
+            x_range=x_range,
+            y_range=y_range,
+        )
+
+        # Drop distance index to save storage space
+        ddf = ddf.reset_index(drop=True)
+
+        # Save ddf to parquet
+        dd.to_parquet(
+            ddf, filename, engine='fastparquet', compression=compression)
+
+        # Open resulting parquet file
+        pf = fp.ParquetFile(filename)
+
+        # Add a new property to the file metadata
+        new_fmd = copy.copy(pf.fmd)
+        new_kv = fp.parquet_thrift.KeyValue()
+        new_kv.key = 'SpatialPointsFrame'
+        new_kv.value = json.dumps(props)
+        new_fmd.key_value_metadata.append(new_kv)
+
+        # Overwrite file metadata
+        fn = os.path.join(filename, '_metadata')
+        fp.writer.write_common_metadata(fn, new_fmd, no_row_groups=False)
+
+        fn = os.path.join(filename, '_common_metadata')
+        fp.writer.write_common_metadata(fn, new_fmd)
+
+    @staticmethod
+    def _build_distance_grid(p):
+        """
+        Build a (2 ** p) x (2 ** p) array containing the Hilbert distance of
+        each discrete location in the grid
+
+        Parameters
+        ----------
+        p: int
+            Hilbert curve order
+
+        Returns
+        -------
+        np.ndarray
+            2D array containing the Hilbert curve distances for a curve with
+            order p
+        """
+        side_length = 2 ** p
+        distance_grid = np.zeros([side_length] * 2, dtype='int')
+        for i in range(side_length):
+            for j in range(side_length):
+                distance_grid[i, j] = (
+                    hc.distance_from_coordinates(p, i, j))
+        return distance_grid
+
+    @staticmethod
+    def _build_partition_grid(dask_divisions, p):
+        """
+        Build a (2 ** p) x (2 ** p) array containing the partition number
+        of each discrete location in the grid
+
+        Parameters
+        ----------
+        dask_divisions: list of int
+            Hilbert distance divisions for the parquet file
+        p: int
+            Hilbert curve order
+
+        Returns
+        -------
+        np.ndarray
+            2D array containing the Hilbert distance partitions for a curve
+            with order p
+        """
+        distance_grid = SpatialPointsFrame._build_distance_grid(p)
+        search_divisions = np.array(
+            list(dask_divisions[1:-1]))
+
+        side_length = 2 ** p
+        partition_grid = np.zeros([side_length] * 2, dtype='int')
+        for i in range(side_length):
+            for j in range(side_length):
+                partition_grid[i, j] = np.searchsorted(
+                    search_divisions,
+                    distance_grid[i, j],
+                    sorter=None,
+                    side='right')
+        return partition_grid
+
+    def __init__(self, filename, persist=False):
+        """
+        Construct a SpatialPointsFrame from a spatially partitioned parquet
+        file
+
+        Parameters
+        ----------
+        filename: str
+            Path to a spatially partitioned parquet file that was created
+            using SpatialPointsFrame.partition_and_write
+        persist: bool (default False)
+            Whether to persist the entire parquet file as a Dask dataframe
+            in memory
+        """
+        _validate_fastparquet()
+
+        # Open parquet file
+        pf = fp.ParquetFile(filename)
+
+        # Check for required metadata
+        if 'SpatialPointsFrame' not in pf.key_value_metadata:
+            raise ValueError("""
+The parquet file at '{filename}'
+does not appear to be spatially partitioned.
+Please construct a spatially partitioned parquet file using the
+SpatialPointsFrame.partition_and_write static method.""".format(
+                filename=filename))
+
+        # Load metadata
+        props = json.loads(pf.key_value_metadata['SpatialPointsFrame'])
+        self._x = props['x']
+        self._y = props['y']
+        self._p = props['p']
+        self._x_range = tuple(props['x_range'])
+        self._y_range = tuple(props['y_range'])
+        self._distance_divisions = tuple(props['distance_divisions'])
+        self._npartitions = len(self._distance_divisions) - 1
+
+        # Compute grids
+        self._partition_grid = SpatialPointsFrame._build_partition_grid(
+            self._distance_divisions, self._p)
+
+        # Compute derived properties
+        n = 2
+        self._side_length = 2 ** self._p
+        self._max_distance = 2 ** (n * self._p) - 1
+        self._x_width = self._x_range[1] - self._x_range[0]
+        self._y_width = self._y_range[1] - self._y_range[0]
+        self._x_bin_width = self._x_width / self._side_length
+        self._y_bin_width = self._y_width / self._side_length
+
+        # Read parquet file
+        self._frame = dd.read_parquet(filename)
+
+        # Persist if requested
+        if persist:
+            self._frame = self._frame.persist()
+
+    def query_partitions(self, x_range, y_range):
+        """
+        Query the underlying parquet file for the partitions that potentially
+        intersect with a given rectangular region.
+
+        Parameters
+        ----------
+        x_range, y_range: tuple
+            Length-2 tuples containing the x and y extents of the query region
+
+        Returns
+        -------
+        dd.DataFrame
+            Dask dataframe containing all data from all partitions that
+            potentially intersect with the specified x_range/y_range box.
+        """
+        # Expand upper range to account for rounding
+        expanded_x_range = [x_range[0],
+                            x_range[1] + self._x_bin_width]
+
+        expanded_y_range = [y_range[0],
+                            y_range[1] + self._y_bin_width]
+
+        # Compute ranges in integer coordinates
+        query_x_range_coord = _data2coord(expanded_x_range,
+                                          self._x_range,
+                                          self._side_length)
+
+        query_y_range_coord = _data2coord(expanded_y_range,
+                                          self._y_range,
+                                          self._side_length)
+
+        # Get corresponding slice of partition grid
+        partition_query = self._partition_grid[
+            slice(*query_x_range_coord), slice(*query_y_range_coord)]
+
+        # Get unique partitions present in slice
+        query_partitions = sorted(np.unique(partition_query))
+
+        if query_partitions:
+            partition_dfs = [self._frame.get_partition(p)
+                             for p in query_partitions]
+            query_frame = dd.concat(partition_dfs)
+            return query_frame
+        else:
+            # return an empty Dask dataframe with the right shape
+            return (self._frame
+                    .get_partition(0)
+                    .map_partitions(lambda df: df.iloc[1:0]))
+
+    # Read-only properties
+    @property
+    def frame(self):
+        """
+        Dask dataframe backed by a spatially partitioned parquet file
+
+        Returns
+        -------
+        dd.DataFrame
+        """
+        return self._frame
+
+    @property
+    def hilbert_distances(self):
+        """
+        Dask series containing the Hilbert distance of each row in frame
+
+        Returns
+        -------
+        dd.Series
+        """
+        x = self.x
+        y = self._y
+        p = self._p
+        x_range = self._x_range
+        y_range = self._y_range
+        return self._frame.map_partitions(
+            _compute_distance, x=x, y=y, p=p,
+            x_range=x_range, y_range=y_range)
+
+    @property
+    def partitions(self):
+        """
+        Dask series containing the partition of each row in frame
+
+        Returns
+        -------
+        dd.Series
+        """
+        search_divisions = np.array(self.distance_divisions[:-1])
+        return self.hilbert_distances.map_partitions(
+            lambda s: pd.Series(
+                np.ones(len(s)) *
+                search_divisions.searchsorted(s.iloc[0], side='right'),
+                dtype='int64',
+                index=s.index))
+
+    @property
+    def x(self):
+        """
+        Column label in frame containing the x coordinate of each row
+        """
+        return self._x
+
+    @property
+    def y(self):
+        """
+        Column label in frame containing the x coordinate of each row
+        """
+        return self._y
+
+    @property
+    def p(self):
+        """
+        Hilbert curve order parameter
+
+        Returns
+        -------
+        int
+        """
+        return self._p
+
+    @property
+    def x_range(self):
+        """
+        x range extents for the entire dataset
+
+        Returns
+        -------
+        x_range: tuple
+            The min (x_range[0]) and max (x_range[1]) x coordinates in frame
+        """
+        return self._x_range
+
+    @property
+    def y_range(self):
+        """
+        y range extents for the entire dataset
+
+        Returns
+        -------
+        y_range: tuple
+            The min (y_range[0]) and max (y_range[1]) y coordinates in frame
+        """
+        return self._y_range
+
+    @property
+    def x_bin_edges(self):
+        """
+        Array of the discrete x-coordinates that points are rounded to
+        in order to compute their Hilbert curve distance
+
+        Returns
+        -------
+        x_bin_edges: np.ndarray
+        """
+        return np.linspace(*self.x_range, self._side_length + 1)
+
+    @property
+    def y_bin_edges(self):
+        """
+        Array of the discrete y-coordinates that points are rounded to
+        in order to compute their Hilbert curve distance
+
+        Returns
+        -------
+        y_bin_edges: np.ndarray
+        """
+        return np.linspace(*self.y_range, self._side_length + 1)
+
+    @property
+    def distance_divisions(self):
+        """
+        tuple of the Hilbert distance divisions corresponding to the
+        partitions in frame
+
+        Returns
+        -------
+        tuple
+        """
+        return self._distance_divisions
+
+    @property
+    def npartitions(self):
+        """
+        The number of partitions in frame
+
+        Returns
+        -------
+        int
+        """
+        return self._npartitions

--- a/datashader/spatial/__init__.py
+++ b/datashader/spatial/__init__.py
@@ -228,9 +228,10 @@ class SpatialPointsFrame(object):
 
         # Validate filename
         if (not isinstance(filename, basestring) or
-                not filename.endswith('.parquet')):
-            raise ValueError(
-                'filename must be a string ending with a .parquet extension')
+                not (filename.endswith('.parquet') or
+                     filename.endswith('.parq'))):
+            raise ValueError("""\
+'filename must be a string ending with a .parquet or .parq extension""")
 
         # Remove any existing directory
         if os.path.exists(filename):

--- a/datashader/spatial/__init__.py
+++ b/datashader/spatial/__init__.py
@@ -152,7 +152,7 @@ class SpatialPointsFrame(object):
 
     Then, construct a SpatialPointsFrame and use it to extract
     subsets of the original dataframe based on x/y range extents.
-    >>> sframe = SpatialPointsFrame(filename, persist=True)
+    >>> sframe = SpatialPointsFrame(filename, persist=True)  # doctest: +SKIP
     ...
     ... def create_image(x_range, y_range):
     ...     cvs = ds.Canvas(x_range=x_range, y_range=y_range)

--- a/datashader/spatial/hilbert_curve.py
+++ b/datashader/spatial/hilbert_curve.py
@@ -2,11 +2,14 @@ from __future__ import absolute_import
 from datashader.utils import ngjit
 from numba import jit, vectorize, int64
 import numpy as np
+import os
 
 """
 Initially based on https://github.com/galtay/hilbert_curve, but specialized
 for 2 dimensions with numba acceleration
 """
+
+NUMBA_DISABLE_JIT = os.environ.get('NUMBA_DISABLE_JIT', 0)
 
 
 @ngjit
@@ -51,7 +54,7 @@ def _hilbert_integer_to_transpose(p, h):
     return x
 
 
-@jit([int64(int64, int64, int64)], nopython=True)
+@ngjit
 def _transpose_to_hilbert_integer(p, x, y):
     """Restore a hilbert integer (`h`) from its transpose (`x`).
 
@@ -115,7 +118,13 @@ def coordinates_from_distance(p, h):
     return x
 
 
-@vectorize([int64(int64, int64, int64)], nopython=True)
+if NUMBA_DISABLE_JIT:
+    vect = np.vectorize
+else:
+    vect = vectorize([int64(int64, int64, int64)], nopython=True)
+
+
+@vect
 def distance_from_coordinates(p, x, y):
     """Return the hilbert distance for a given set of coordinates.
 

--- a/datashader/spatial/hilbert_curve.py
+++ b/datashader/spatial/hilbert_curve.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from datashader.utils import ngjit
 from numba import jit, vectorize, int64
 import numpy as np
 
@@ -7,7 +9,7 @@ for 2 dimensions with numba acceleration
 """
 
 
-@jit(nopython=True)
+@ngjit
 def _int_2_binary(n, width):
     """Return a binary byte array representation of `n` zero padded to `width`
     bits."""
@@ -19,7 +21,7 @@ def _int_2_binary(n, width):
     return res
 
 
-@jit(nopython=True)
+@ngjit
 def _binary_2_int(bin_vec):
     """Convert a binary byte array to an integer"""
     res = 0
@@ -31,7 +33,7 @@ def _binary_2_int(bin_vec):
     return res
 
 
-@jit(nopython=True)
+@ngjit
 def _hilbert_integer_to_transpose(p, h):
     """Store a hilbert integer (`h`) as its transpose (`x`).
 
@@ -72,7 +74,7 @@ def _transpose_to_hilbert_integer(p, x, y):
     return h
 
 
-@jit(nopython=True)
+@ngjit
 def coordinates_from_distance(p, h):
     """Return the coordinates for a given hilbert distance.
 

--- a/datashader/spatial/hilbert_curve.py
+++ b/datashader/spatial/hilbert_curve.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from datashader.utils import ngjit
-from numba import jit, vectorize, int64
+from numba import vectorize, int64
 import numpy as np
 import os
 

--- a/datashader/spatial/hilbert_curve.py
+++ b/datashader/spatial/hilbert_curve.py
@@ -1,0 +1,160 @@
+from numba import jit, vectorize, int64
+import numpy as np
+
+"""
+Initially based on https://github.com/galtay/hilbert_curve, but specialized
+for 2 dimensions with numba acceleration
+"""
+
+
+@jit(nopython=True)
+def _int_2_binary(n, width):
+    """Return a binary byte array representation of `n` zero padded to `width`
+    bits."""
+    res = np.zeros(width, dtype=np.uint8)
+    i = 0
+    for i in range(width):
+        res[width - i - 1] = n % 2
+        n = n >> 1
+    return res
+
+
+@jit(nopython=True)
+def _binary_2_int(bin_vec):
+    """Convert a binary byte array to an integer"""
+    res = 0
+    next_val = 1
+    width = len(bin_vec)
+    for i in range(width):
+        res += next_val*bin_vec[width - i - 1]
+        next_val <<= 1
+    return res
+
+
+@jit(nopython=True)
+def _hilbert_integer_to_transpose(p, h):
+    """Store a hilbert integer (`h`) as its transpose (`x`).
+
+    Args:
+        p (int): iterations to use in the hilbert curve
+        h (int): integer distance along hilbert curve
+    Returns:
+        x (list): transpose of h
+                  (n components with values between 0 and 2**p-1)
+    """
+    n = 2
+    h_bits = _int_2_binary(h, p * n)
+
+    x = [_binary_2_int(h_bits[i::n]) for i in range(n)]
+    return x
+
+
+@jit([int64(int64, int64, int64)], nopython=True)
+def _transpose_to_hilbert_integer(p, x, y):
+    """Restore a hilbert integer (`h`) from its transpose (`x`).
+
+    Args:
+        p (int): iterations to use in the hilbert curve
+        x (list): transpose of h
+                  (n components with values between 0 and 2**p-1)
+
+    Returns:
+        h (int): integer distance along hilbert curve
+    """
+    bin1 = _int_2_binary(x, p)
+    bin2 = _int_2_binary(y, p)
+    concat = np.zeros(2*p, dtype=np.uint8)
+    for i in range(p):
+        concat[2*i] = bin1[i]
+        concat[2*i+1] = bin2[i]
+
+    h = _binary_2_int(concat)
+    return h
+
+
+@jit(nopython=True)
+def coordinates_from_distance(p, h):
+    """Return the coordinates for a given hilbert distance.
+
+    Args:
+        p (int): iterations to use in the hilbert curve
+        h (int): integer distance along hilbert curve
+    Returns:
+        x (list): transpose of h
+                  (n components with values between 0 and 2**p-1)
+    """
+
+    n = 2
+    x = _hilbert_integer_to_transpose(p, h)
+    Z = 2 << (p-1)
+
+    # Gray decode by H ^ (H/2)
+    t = x[n-1] >> 1
+    for i in range(n-1, 0, -1):
+        x[i] ^= x[i-1]
+    x[0] ^= t
+
+    # Undo excess work
+    Q = 2
+    while Q != Z:
+        P = Q - 1
+        for i in range(n-1, -1, -1):
+            if x[i] & Q:
+                # invert
+                x[0] ^= P
+            else:
+                # exchange
+                t = (x[0] ^ x[i]) & P
+                x[0] ^= t
+                x[i] ^= t
+        Q <<= 1
+
+    # done
+    return x
+
+
+@vectorize([int64(int64, int64, int64)], nopython=True)
+def distance_from_coordinates(p, x, y):
+    """Return the hilbert distance for a given set of coordinates.
+
+    Args:
+        p (int): iterations to use in the hilbert curve
+        x_in (list): transpose of h
+                     (n components with values between 0 and 2**p-1)
+
+    Returns:
+        h (int): integer distance along hilbert curve
+    """
+    n = 2
+
+    x = np.array([x, y], dtype=np.int64)
+
+    M = 1 << (p - 1)
+
+    # Inverse undo excess work
+    Q = M
+    while Q > 1:
+        P = Q - 1
+        for i in range(n):
+            if x[i] & Q:
+                x[0] ^= P
+            else:
+                t = (x[0] ^ x[i]) & P
+                x[0] ^= t
+                x[i] ^= t
+        Q >>= 1
+
+    # Gray encode
+    for i in range(1, n):
+        x[i] ^= x[i-1]
+    t = 0
+    Q = M
+    while Q > 1:
+        if x[n-1] & Q:
+            t ^= Q - 1
+        Q >>= 1
+    for i in range(n):
+        x[i] ^= t
+
+    h = _transpose_to_hilbert_integer(p, x[0], x[1])
+    return h

--- a/datashader/tests/test_spatial.py
+++ b/datashader/tests/test_spatial.py
@@ -29,6 +29,8 @@ def df():
 @pytest.fixture()
 def s_points_frame(tmp_path, df):
 
+    # Work around https://bugs.python.org/issue33617
+    tmp_path = str(tmp_path)
     p = 5
     filename = os.path.join(tmp_path, 'spatial_points.parquet')
 
@@ -100,6 +102,8 @@ def test_query_partitions(s_points_frame, x_range, y_range):
 
 
 def test_validate_parquet_file(df, tmp_path):
+    # Work around https://bugs.python.org/issue33617
+    tmp_path = str(tmp_path)
 
     # Write DataFrame to parquet
     filename = os.path.join(tmp_path, 'df.parquet')

--- a/datashader/tests/test_spatial.py
+++ b/datashader/tests/test_spatial.py
@@ -1,0 +1,113 @@
+import os
+import pytest
+import numpy as np
+import pandas as pd
+
+from datashader.spatial import SpatialPointsFrame
+
+
+@pytest.fixture()
+def df():
+    N = 1000
+    np.random.seed(25)
+
+    df = pd.DataFrame({
+        'x': np.random.rand(N),
+        'y': np.random.rand(N) * 2,
+        'a': np.random.randn(N)
+    })
+
+    # Make sure we have x/y values of 0 and 1 represented so that
+    # autocomputed ranges are predictable
+    df.x.iloc[0] = 0.0
+    df.x.iloc[-1] = 1.0
+    df.y.iloc[0] = 0.0
+    df.y.iloc[-1] = 2.0
+    return df
+
+
+@pytest.fixture()
+def s_points_frame(tmp_path, df):
+
+    p = 5
+    filename = os.path.join(tmp_path, 'spatial_points.parquet')
+
+    SpatialPointsFrame.partition_and_write(
+        df, 'x', 'y', filename=filename, p=p, npartitions=10)
+
+    return SpatialPointsFrame(filename=filename)
+
+
+def test_spacial_points_frame_properties(s_points_frame):
+    assert s_points_frame.x == 'x'
+    assert s_points_frame.y == 'y'
+    assert s_points_frame.p == 5
+    assert s_points_frame.npartitions == 10
+    assert s_points_frame.x_range == (0, 1)
+    assert s_points_frame.y_range == (0, 2)
+
+    # x_bin_edges
+    np.testing.assert_array_equal(
+        s_points_frame.x_bin_edges,
+        np.linspace(0.0, 1.0, 2 ** 5 + 1))
+
+    # y_bin_edges
+    np.testing.assert_array_equal(
+        s_points_frame.y_bin_edges,
+        np.linspace(0.0, 2.0, 2 ** 5 + 1))
+
+    # distance_divisions
+    distance_divisions = s_points_frame.distance_divisions
+    assert len(distance_divisions) == 10 + 1
+
+
+@pytest.mark.parametrize('x_range,y_range', [
+    ((0, 0.2), (0, 0.2)),
+    ((0.3, 1.0), (0.5, 1.5)),
+    ((5, 10), (5, 10))  # Outside of bounds
+])
+def test_query_partitions(s_points_frame, x_range, y_range):
+
+    # Get original
+    ddf = s_points_frame.frame
+
+    # Query subset
+    query_ddf = s_points_frame.query_partitions(x_range, y_range)
+
+    # Make sure we have less partitions
+    assert query_ddf.npartitions < ddf.npartitions
+
+    # Make sure query has less rows
+    assert len(query_ddf) < len(ddf)
+
+    # Make sure query includes all of the rows in the original that
+    # reside in the query region
+    df = ddf.compute()
+    query_df = query_ddf.compute()
+
+    range_inds = (
+        (x_range[0] <= df.x) & (df.x <= x_range[1]) &
+        (y_range[0] <= df.y) & (df.y <= y_range[1]))
+
+    query_range_inds = (
+        (x_range[0] <= query_df.x) & (query_df.x <= x_range[1]) &
+        (y_range[0] <= query_df.y) & (query_df.y <= y_range[1]))
+
+    # Check that the two methods produce the same set of rows
+    df1 = df.loc[range_inds].sort_values(['x', 'y', 'a'])
+    df2 = query_df.loc[query_range_inds].sort_values(['x', 'y', 'a'])
+    pd.testing.assert_frame_equal(df1, df2)
+
+
+def test_validate_parquet_file(df, tmp_path):
+
+    # Write DataFrame to parquet
+    filename = os.path.join(tmp_path, 'df.parquet')
+    df.to_parquet(filename, engine='fastparquet')
+
+    # Try to construct a SpatialPointsFrame from it
+    with pytest.raises(ValueError) as e:
+        SpatialPointsFrame(filename)
+
+    assert 'SpatialPointsFrame.partition_and_write' in str(e.value)
+

--- a/datashader/tests/test_spatial.py
+++ b/datashader/tests/test_spatial.py
@@ -2,7 +2,7 @@ import os
 import pytest
 import numpy as np
 import pandas as pd
-
+import dask.dataframe as dd
 from datashader.spatial import SpatialPointsFrame
 
 
@@ -103,7 +103,8 @@ def test_validate_parquet_file(df, tmp_path):
 
     # Write DataFrame to parquet
     filename = os.path.join(tmp_path, 'df.parquet')
-    df.to_parquet(filename, engine='fastparquet')
+    ddf = dd.from_pandas(df, npartitions=4)
+    ddf.to_parquet(filename, engine='fastparquet')
 
     # Try to construct a SpatialPointsFrame from it
     with pytest.raises(ValueError) as e:

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requires = [
 
 extras_require = {
     'tests': [
-        'pytest ==3.6.3',
+        'pytest ==3.9.3',
         'pytest-benchmark ==3.0.0',
         'flake8',
         'nbsmoke >=0.2.6',

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ extras_require = {
         'pytest-benchmark ==3.0.0',
         'flake8',
         'nbsmoke >=0.2.6',
-        'fastparquet >=0.2.1',  # optional dependency
+        'fastparquet >=0.1.6',  # optional dependency
     ],
     'examples': [],
     'examples_extra':[

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ extras_require = {
         'pytest-benchmark ==3.0.0',
         'flake8',
         'nbsmoke >=0.2.6',
+        'fastparquet >=0.2.1',  # optional dependency
     ],
     'examples': [],
     'examples_extra':[


### PR DESCRIPTION
This PR brings the functionality prototyped in https://github.com/jonmmease/hilbert_frame into the datashader project.

The class `HilbertFrame2D` has been renamed `SpatialPointsFrame` as I think this is a more informative and more precise name.  If we work out a way to support spatial partitioning of lines or trimeshes in the future then we can add additional `Spatial*Frame` classes.

The implementation has been substantially cleaned up and the first three items in https://github.com/jonmmease/hilbert_frame/issues/3 have been addressed

1) The metadata is now stored directly in the parquet file as custom metadata, so the pickle file is no more.
2) The Hilbert distance index column is no longer stored in the resulting parquet file.  So now there is negligible storage overhead associated with storing a data set in this spatially partitioned format.  And, the file can still be loaded directly by pandas/dask/fastparquet/etc. for use in non-spatial contexts.
3) Numpy-style doc strings have been added

4) A test suite has been added

The last remaining item is documentation.

I would appreciate thoughts on how this functionality could be integrated into the existing documentation structure.

I have the three notebooks I posed in https://github.com/jonmmease/hilbert_frame that could be a starting point.  We could also consider distributing the OSM or census parquet datasets in this form and then have the corresponding topics take advantage of the spatial partitioning.

cc @jbednar @philippjfr 
