### PR TITLE
Added missing entry to datasets.yml

### DIFF
--- a/examples/datasets.yml
+++ b/examples/datasets.yml
@@ -12,6 +12,11 @@ data:
     files:
       - nyc_crime.csv
 
+  - url: https://s3.amazonaws.com/datashader-data/nyc_taxi_wide.parq
+    title: 'NYC Taxi Data Wide'
+    files:
+      - nyc_taxi_wide.parq
+
   - url: http://s3.amazonaws.com/datashader-data/nyc_taxi.zip
     title: 'NYC Taxi Data'
     files:


### PR DESCRIPTION
Added an entry to fetch `nyc_taxi_wide.parq` needed by the updated dashboard example. Longer term, it would be good to eliminate the redundancy of having this entry along with `nyc_taxi.csv`.