### PR TITLE
Convert SpatialPointsFrame to a Dask DataFrame subclass

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -165,7 +165,8 @@ class Canvas(object):
 
         if (isinstance(source, SpatialPointsFrame) and
                 source.spatial is not None and
-                source.spatial.x == x and source.spatial.y == y):
+                source.spatial.x == x and source.spatial.y == y and
+                self.x_range is not None and self.y_range is not None):
 
             source = source.spatial_query(
                 x_range=self.x_range, y_range=self.y_range)

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -164,7 +164,9 @@ class Canvas(object):
             agg = count_rdn()
 
         if (isinstance(source, SpatialPointsFrame) and
-                source.spatial_x == x and source.spatial_y == y):
+                source.spatial is not None and
+                source.spatial.x == x and source.spatial.y == y):
+
             source = source.query_partitions(
                 x_range=self.x_range, y_range=self.y_range)
 

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -10,6 +10,7 @@ from six import string_types
 from xarray import DataArray, Dataset
 from collections import OrderedDict
 
+from datashader.spatial import SpatialPointsFrame
 from .utils import Dispatcher, ngjit, calc_res, calc_bbox, orient_array, compute_coords
 from .utils import get_indices, dshape_from_pandas, dshape_from_dask
 from .utils import Expr # noqa (API import)
@@ -161,6 +162,12 @@ class Canvas(object):
         from .reductions import count as count_rdn
         if agg is None:
             agg = count_rdn()
+
+        if (isinstance(source, SpatialPointsFrame) and
+                source.spatial_x == x and source.spatial_y == y):
+            source = source.query_partitions(
+                x_range=self.x_range, y_range=self.y_range)
+
         return bypixel(source, self, Point(x, y), agg)
 
     def line(self, source, x, y, agg=None, axis=0):

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -167,7 +167,7 @@ class Canvas(object):
                 source.spatial is not None and
                 source.spatial.x == x and source.spatial.y == y):
 
-            source = source.query_partitions(
+            source = source.spatial_query(
                 x_range=self.x_range, y_range=self.y_range)
 
         return bypixel(source, self, Point(x, y), agg)

--- a/datashader/spatial/__init__.py
+++ b/datashader/spatial/__init__.py
@@ -495,7 +495,7 @@ SpatialPointsFrame.partition_and_write static method.""".format(
             self._distance_divisions = distance_divisions
 
             self._partition_grid = _build_partition_grid(
-                self._distance_divisions, self._p)
+                list(self._distance_divisions), self._p)
 
             # Compute derived properties
             n = 2

--- a/datashader/spatial/__init__.py
+++ b/datashader/spatial/__init__.py
@@ -371,10 +371,10 @@ SpatialPointsFrame.partition_and_write static method.""".format(
     def persist(self, **kwargs):
         """Persist this dask collection into memory along with spatial metadata
 
-        Refer to the dask.DataFrame for the full docstring. This
-        method extends the default behavior to ensure the spatial
-        properties of the SpatialPointsFrame are inherited by the
-        in-memory copy.
+        Refer to dask.dataframe.DataFrame.persist for the full
+        docstring. This method extends the default behavior of
+        .persist() to ensure the spatial properties of the
+        SpatialPointsFrame are inherited by the in-memory copy.
 
         Parameters
         ----------

--- a/datashader/spatial/__init__.py
+++ b/datashader/spatial/__init__.py
@@ -369,23 +369,12 @@ SpatialPointsFrame.partition_and_write static method.""".format(
             self._spatial = self.SpatialProperties(self, **props)
 
     def persist(self, **kwargs):
-        """Persist this dask collection into memory
+        """Persist this dask collection into memory along with spatial metadata
 
-        This turns a lazy Dask collection into a Dask collection with the same
-        metadata, but now with the results fully computed or actively computing
-        in the background.
-
-        The action of function differs significantly depending on the active
-        task scheduler.  If the task scheduler supports asynchronous computing,
-        such as is the case of the dask.distributed scheduler, then persist
-        will return *immediately* and the return value's task graph will
-        contain Dask Future objects.  However if the task scheduler only
-        supports blocking computation then the call to persist will *block*
-        and the return value's task graph will contain concrete Python results.
-
-        This function is particularly useful when using distributed systems,
-        because the results will be kept in distributed memory, rather than
-        returned to the local process as with compute.
+        Refer to the dask.DataFrame for the full docstring. This
+        method extends the default behavior to ensure the spatial
+        properties of the SpatialPointsFrame are inherited by the
+        in-memory copy.
 
         Parameters
         ----------

--- a/datashader/spatial/__init__.py
+++ b/datashader/spatial/__init__.py
@@ -158,7 +158,7 @@ class SpatialPointsFrame(dd.DataFrame):
 
     Then, construct a SpatialPointsFrame and use it to extract
     subsets of the original dataframe based on x/y range extents.
-    >>> sframe = SpatialPointsFrame(filename, persist=True)  # doctest: +SKIP
+    >>> sframe = SpatialPointsFrame.from_parquet(filename).persist()  # doctest: +SKIP
     ...
     ... def create_image(x_range, y_range):
     ...     cvs = ds.Canvas(x_range=x_range, y_range=y_range)
@@ -328,9 +328,6 @@ Received value of type {typ}""".format(typ=type(df)))
         filename: str
             Path to a spatially partitioned parquet file that was created
             using SpatialPointsFrame.partition_and_write
-        persist: bool (default False)
-            Whether to persist the entire parquet file as a Dask dataframe
-            in memory
 
         Returns
         -------

--- a/datashader/spatial/__init__.py
+++ b/datashader/spatial/__init__.py
@@ -332,7 +332,7 @@ Received value of type {typ}""".format(typ=type(df)))
         Returns
         -------
         SpatialPointsFrame
-            A SpatialDataFrame reconstructed from disk
+            A spatially sorted Dask dataframe reconstructed from disk
         """
         _validate_fastparquet()
 
@@ -420,7 +420,9 @@ SpatialPointsFrame.partition_and_write static method.""".format(
     def spatial_query(self, x_range, y_range):
         """
         Query the underlying parquet file for the partitions that potentially
-        intersect with a given rectangular region.
+        intersect with a given rectangular region.  Typically returns some data 
+        outside of the specified ranges, but is guaranteed not to exclude any
+        data inside the range.
 
         Parameters
         ----------

--- a/datashader/spatial/__init__.py
+++ b/datashader/spatial/__init__.py
@@ -372,12 +372,12 @@ SpatialPointsFrame.partition_and_write static method.""".format(
         self._x = props.get('x')
         self._y = props.get('y')
         self._p = props.get('p')
-        self._x_range = tuple(props.get('x_range', (None, None))
-        self._y_range = tuple(props.get('y_range', (None, None))
+        self._x_range = tuple(props.get('x_range', (None, None)))
+        self._y_range = tuple(props.get('y_range', (None, None)))
         self._distance_divisions = tuple(props.get('distance_divisions', (None, None)))
         self._spatial = bool(props)
 
-        if not self_spatial:
+        if not self._spatial:
             return
 
         self._partition_grid = _build_partition_grid(

--- a/datashader/spatial/__init__.py
+++ b/datashader/spatial/__init__.py
@@ -162,7 +162,7 @@ class SpatialPointsFrame(dd.DataFrame):
     ...
     ... def create_image(x_range, y_range):
     ...     cvs = ds.Canvas(x_range=x_range, y_range=y_range)
-    ...     df = sframe.query_partitions(x_range, y_range)
+    ...     df = sframe.spatial_query(x_range, y_range)
     ...     agg = cvs.points(df, 'x', 'y')
     ...     return tf.dynspread(tf.shade(agg))
     ...
@@ -417,7 +417,7 @@ SpatialPointsFrame.partition_and_write static method.""".format(
         persisted._set_spatial_props(props)
         return persisted
 
-    def query_partitions(self, x_range, y_range):
+    def spatial_query(self, x_range, y_range):
         """
         Query the underlying parquet file for the partitions that potentially
         intersect with a given rectangular region.

--- a/datashader/tests/test_spatial.py
+++ b/datashader/tests/test_spatial.py
@@ -41,25 +41,25 @@ def s_points_frame(tmp_path, df):
 
 
 def test_spacial_points_frame_properties(s_points_frame):
-    assert s_points_frame.x == 'x'
-    assert s_points_frame.y == 'y'
-    assert s_points_frame.p == 5
+    assert s_points_frame.spatial_x == 'x'
+    assert s_points_frame.spatial_y == 'y'
+    assert s_points_frame.spatial_p == 5
     assert s_points_frame.npartitions == 10
-    assert s_points_frame.x_range == (0, 1)
-    assert s_points_frame.y_range == (0, 2)
+    assert s_points_frame.spatial_x_range == (0, 1)
+    assert s_points_frame.spatial_y_range == (0, 2)
 
     # x_bin_edges
     np.testing.assert_array_equal(
-        s_points_frame.x_bin_edges,
+        s_points_frame.spatial_x_bin_edges,
         np.linspace(0.0, 1.0, 2 ** 5 + 1))
 
     # y_bin_edges
     np.testing.assert_array_equal(
-        s_points_frame.y_bin_edges,
+        s_points_frame.spatial_y_bin_edges,
         np.linspace(0.0, 2.0, 2 ** 5 + 1))
 
     # distance_divisions
-    distance_divisions = s_points_frame.distance_divisions
+    distance_divisions = s_points_frame.spatial_distance_divisions
     assert len(distance_divisions) == 10 + 1
 
 
@@ -71,7 +71,7 @@ def test_spacial_points_frame_properties(s_points_frame):
 def test_query_partitions(s_points_frame, x_range, y_range):
 
     # Get original
-    ddf = s_points_frame.frame
+    ddf = s_points_frame
 
     # Query subset
     query_ddf = s_points_frame.query_partitions(x_range, y_range)

--- a/datashader/tests/test_spatial.py
+++ b/datashader/tests/test_spatial.py
@@ -79,7 +79,7 @@ def test_query_partitions(s_points_frame, x_range, y_range):
     ddf = s_points_frame
 
     # Query subset
-    query_ddf = s_points_frame.query_partitions(x_range, y_range)
+    query_ddf = s_points_frame.spatial_query(x_range, y_range)
 
     # Make sure we have less partitions
     assert query_ddf.npartitions < ddf.npartitions
@@ -116,7 +116,7 @@ def test_aggregation_partitions(s_points_frame, x_range, y_range):
     df = s_points_frame.compute()
 
     # Query subset
-    query_ddf = s_points_frame.query_partitions(x_range, y_range)
+    query_ddf = s_points_frame.spatial_query(x_range, y_range)
 
     # Create canvas
     cvs = Canvas(x_range=x_range, y_range=y_range)

--- a/datashader/tests/test_spatial.py
+++ b/datashader/tests/test_spatial.py
@@ -45,7 +45,7 @@ def s_points_frame(request, tmp_path, df):
     return spf
 
 
-def test_spacial_points_frame_properties(s_points_frame):
+def test_spatial_points_frame_properties(s_points_frame):
     assert s_points_frame.spatial.x == 'x'
     assert s_points_frame.spatial.y == 'y'
     assert s_points_frame.spatial.p == 5

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -362,7 +362,7 @@ def dshape_from_pandas_helper(col):
         ))
         return datashape.Categorical(col.cat.categories.values,
                                      type=cat_dshape,
-                                     ordered=col.cat.categorical.ordered)
+                                     ordered=col.cat.ordered)
     elif col.dtype.kind == 'M':
         tz = getattr(col.dtype, 'tz', None)
         if tz is not None:


### PR DESCRIPTION
Addresses https://github.com/pyviz/datashader/issues/705

This PR converts the `SpatialPointsFrame` class into a subclass of `dask.dataframe.DataFrame` to simplify the integration with existing libraries such as Holoviews.

The existing properties have now been prefixed by `spatial_` to reduce the likelihood of collisions with dataframe columns.

cc @philippjfr