### PR TITLE
Fix memory explosion when auto-calculating canvas range extents with dask

### DIFF
--- a/datashader/dask.py
+++ b/datashader/dask.py
@@ -31,8 +31,13 @@ def dask_pipeline(df, schema, canvas, glyph, summary):
 
 
 def shape_bounds_st_and_axis(df, canvas, glyph):
-    x_range = canvas.x_range or glyph.compute_x_bounds_dask(df)
-    y_range = canvas.y_range or glyph.compute_y_bounds_dask(df)
+    if not canvas.x_range or not canvas.y_range:
+        x_extents, y_extents = glyph.compute_bounds_dask(df)
+    else:
+        x_extents, y_extents = None, None
+
+    x_range = canvas.x_range or x_extents
+    y_range = canvas.y_range or y_extents
     x_min, x_max, y_min, y_max = bounds = compute(*(x_range + y_range))
     x_range, y_range = (x_min, x_max), (y_min, y_max)
 

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -420,6 +420,43 @@ def test_line_autorange(df, x, y, ax):
     assert_eq(agg, out)
 
 
+def test_line_x_constant_autorange():
+    # axis1 y constant
+    df = pd.DataFrame({
+        'y0': [0, 0, 0],
+        'y1': [-4, 0, 4],
+        'y2': [0, 0, 0],
+    })
+
+    x = np.array([-4, 0, 4])
+    y = ['y0', 'y1', 'y2']
+    ax = 1
+
+    axis = ds.core.LinearAxis()
+    lincoords = axis.compute_index(
+        axis.compute_scale_and_translate((-4., 4.), 9), 9)
+
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    cvs = ds.Canvas(plot_width=9, plot_height=9)
+
+    agg = cvs.line(ddf, x, y, ds.count(), axis=ax)
+
+    sol = np.array([[0, 0, 0, 0, 1, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 1, 0, 0, 0],
+                    [0, 0, 1, 0, 0, 0, 1, 0, 0],
+                    [0, 1, 0, 0, 0, 0, 0, 1, 0],
+                    [3, 1, 1, 1, 1, 1, 1, 1, 3],
+                    [0, 1, 0, 0, 0, 0, 0, 1, 0],
+                    [0, 0, 1, 0, 0, 0, 1, 0, 0],
+                    [0, 0, 0, 1, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 1, 0, 0, 0, 0]], dtype='i4')
+
+    out = xr.DataArray(sol, coords=[lincoords, lincoords],
+                       dims=['y', 'x'])
+    assert_eq(agg, out)
+
+
 def test_log_axis_line():
     axis = ds.core.LogAxis()
     logcoords = axis.compute_index(axis.compute_scale_and_translate((1, 10), 2), 2)


### PR DESCRIPTION
This PR improves the Canvas autorange logic to avoid bringing each full x/y array into memory in order to compute the min/max values.

This fixes  #668 for me.  Here is the test case I I've been using to diagnose and test this PR.  I started a Dask distributed instance on a large workstation and persisted the ~3-billion point OSM dataset into memory. After this persist, the Dask dashboard reports ~28GB memory used.  Then I set up a VM with 8GB of RAM and connected it as a client of the distributed scheduler. I then performed a `cvs.points` aggregation without specifying `x_range`/`y_range`, causing the autorange logic to be invoked. 

```
import dask.dataframe as dd
import datashader as ds
osm = dd.read_parquet('/path/to/osm-3billion.parq/').persist()
cvs = ds.Canvas()
agg = cvs.points(osm, x='x', y='y')
```

Before these changes, the memory usage of the client would climb steadily until the kernel died.  With these changes, the aggregation completes successfully with no noticeable increase in memory usage on the client.

cc @jacobtomlinson