### PR TITLE
Filled area support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+pip-wheel-metadata/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -44,6 +45,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+test_tiles_output/
 
 # Translations
 *.mo
@@ -63,6 +65,7 @@ target/
 
 #Editor files
 *~
+\.idea/
 
 # Example output, notes
 examples/times

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -328,7 +328,7 @@ The axis argument to Canvas.line must be 0 or 1
 
         return bypixel(source, self, glyph, agg)
 
-    def area(self, source, x, y, agg=None):
+    def area(self, source, x, y, agg=None, axis=0):
         """Compute a reduction by pixel, mapping data to pixels as a filled
         area region
 
@@ -348,15 +348,15 @@ The axis argument to Canvas.line must be 0 or 1
             Reduction to compute. Default is ``count()``.
         """
         #
-        from .glyphs import AreaToZero, AreaToLine
+        from .glyphs import AreaToZeroAxis0, AreaToLineAxis0
         from .reductions import any as any_rdn
         if agg is None:
             agg = any_rdn()
 
         if isinstance(y, (list, tuple)):
-            glyph = AreaToLine(x, tuple(y))
+            glyph = AreaToLineAxis0(x, tuple(y))
         else:
-            glyph = AreaToZero(x, y)
+            glyph = AreaToZeroAxis0(x, y)
 
         return bypixel(source, self, glyph, agg)
 

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -328,6 +328,37 @@ The axis argument to Canvas.line must be 0 or 1
 
         return bypixel(source, self, glyph, agg)
 
+    def area(self, source, x, y, agg=None):
+        """Compute a reduction by pixel, mapping data to pixels as a filled
+        area region
+
+        Parameters
+        ----------
+        source : pandas.DataFrame, dask.DataFrame, or xarray.DataArray/Dataset
+            The input datasource.
+        x: str
+            Column name for the x coordinates of the area boundary.
+        y: str or list of str
+            * str: Column name for the y coordinates of the area boundary. The
+            area to be filled is the region between this y coordinate and y=0.
+            * list of 2 str: Columns names for the two y coordinate of the
+            area boundary. The area to be filled is the region between these
+            two y coordinates.
+        agg : Reduction, optional
+            Reduction to compute. Default is ``count()``.
+        """
+        #
+        from .glyphs import AreaToZero, AreaToLine
+        from .reductions import any as any_rdn
+        if agg is None:
+            agg = any_rdn()
+
+        if isinstance(y, (list, tuple)):
+            glyph = AreaToLine(x, tuple(y))
+        else:
+            glyph = AreaToZero(x, y)
+
+        return bypixel(source, self, glyph, agg)
 
     # TODO re 'untested', below: Consider replacing with e.g. a 3x3
     # array in the call to Canvas (plot_height=3,plot_width=3), then

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -539,7 +539,7 @@ class LinesAxis1Ragged(_PointLike):
         return extend
 
 
-class AreaToZero(_PointLike):
+class AreaToZeroAxis0(_PointLike):
     """A filled area glyph
     The area to be filled is the region from the line defined by ``x`` and
     ``y`` and the y=0 line
@@ -583,7 +583,7 @@ class AreaToZero(_PointLike):
     def _build_extend(self, x_mapper, y_mapper, info, append):
         draw_trapezoid_y = _build_draw_trapezoid_y(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
-        extend_area = _build_extend_area_to_zero(
+        extend_area = _build_extend_area_axis0(
             draw_trapezoid_y, map_onto_pixel)
         x_name = self.x
         y_name = self.y
@@ -592,12 +592,12 @@ class AreaToZero(_PointLike):
             xs = df[x_name].values
             ys = df[y_name].values
             cols = aggs + info(df)
-            extend_area(vt, bounds, xs, ys, plot_start, *cols)
+            extend_area(vt, bounds, xs, ys, np.array([0.0]), plot_start, *cols)
 
         return extend
 
 
-class AreaToLine(_PointLike):
+class AreaToLineAxis0(_PointLike):
     """A filled area glyph
     The area to be filled is the region from the line defined by ``x`` and
     ``y[0]`` and the line defined by ``x`` and ``y[1]``.
@@ -662,7 +662,7 @@ class AreaToLine(_PointLike):
     def _build_extend(self, x_mapper, y_mapper, info, append):
         draw_trapezoid_y = _build_draw_trapezoid_y(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
-        extend_area = _build_extend_area_to_line(
+        extend_area = _build_extend_area_axis0(
             draw_trapezoid_y, map_onto_pixel)
         x_name = self.x
         y_names = self.y
@@ -1410,7 +1410,7 @@ def _build_extend_line_axis1_ragged(draw_line, map_onto_pixel):
     return extend_line
 
 
-def _build_extend_area_to_zero(draw_trapezoid_y, map_onto_pixel):
+def _build_extend_area_to_zero_axis0(draw_trapezoid_y, map_onto_pixel):
     @ngjit
     def extend_area(vt, bounds, xs, ys, plot_start, *aggs_and_cols):
         """Aggregate filled area along a line formed by
@@ -1449,7 +1449,7 @@ def _build_extend_area_to_zero(draw_trapezoid_y, map_onto_pixel):
     return extend_area
 
 
-def _build_extend_area_to_line(draw_trapezoid_y, map_onto_pixel):
+def _build_extend_area_axis0(draw_trapezoid_y, map_onto_pixel):
     @ngjit
     def extend_area(vt, bounds, xs, ys0, ys1, plot_start, *aggs_and_cols):
         """Aggregate filled area between the line formed by

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -8,7 +8,42 @@ from .utils import ngjit, isreal, Expr
 
 class Glyph(Expr):
     """Base class for glyphs."""
-    pass
+    @staticmethod
+    def maybe_expand_bounds(bounds):
+        minval, maxval = bounds
+        if not (np.isfinite(minval) and np.isfinite(maxval)):
+            minval, maxval = -1.0, 1.0
+        elif minval == maxval:
+            minval, maxval = minval-1, minval+1
+        return minval, maxval
+
+    @staticmethod
+    @ngjit
+    def _compute_x_bounds(xs):
+        minval = np.inf
+        maxval = -np.inf
+        for x in xs:
+            if not np.isnan(x):
+                if x < minval:
+                    minval = x
+                if x > maxval:
+                    maxval = x
+
+        return minval, maxval
+
+    @staticmethod
+    @ngjit
+    def _compute_y_bounds(ys):
+        minval = np.inf
+        maxval = -np.inf
+        for y in ys:
+            if not np.isnan(y):
+                if y < minval:
+                    minval = y
+                if y > maxval:
+                    maxval = y
+
+        return minval, maxval
 
 
 class _PointLike(Glyph):
@@ -45,43 +80,6 @@ class _PointLike(Glyph):
     def compute_y_bounds(self, df):
         bounds = self._compute_y_bounds(df[self.y].values)
         return self.maybe_expand_bounds(bounds)
-
-    @staticmethod
-    @ngjit
-    def _compute_x_bounds(xs):
-        minval = np.inf
-        maxval = -np.inf
-        for x in xs:
-            if not np.isnan(x):
-                if x < minval:
-                    minval = x
-                if x > maxval:
-                    maxval = x
-
-        return minval, maxval
-
-    @staticmethod
-    @ngjit
-    def _compute_y_bounds(ys):
-        minval = np.inf
-        maxval = -np.inf
-        for y in ys:
-            if not np.isnan(y):
-                if y < minval:
-                    minval = y
-                if y > maxval:
-                    maxval = y
-
-        return minval, maxval
-
-    @staticmethod
-    def maybe_expand_bounds(bounds):
-        minval, maxval = bounds
-        if not (np.isfinite(minval) and np.isfinite(maxval)):
-            minval, maxval = -1.0, 1.0
-        elif minval == maxval:
-            minval, maxval = minval-1, minval+1
-        return minval, maxval
 
     @memoize
     def compute_bounds_dask(self, ddf):
@@ -314,7 +312,6 @@ class LinesAxis1(_PointLike):
         if len(unique_y_measures) > 1:
             raise ValueError('y columns must have the same data type')
 
-
     def required_columns(self):
         return self.x + self.y
 
@@ -490,11 +487,11 @@ class LinesAxis1Ragged(_PointLike):
 
         if not isinstance(in_dshape[str(self.x)], RaggedDtype):
             raise ValueError('x must be a RaggedArray')
-        elif not isinstance(in_dshape[str(self.x)], RaggedDtype):
+        elif not isinstance(in_dshape[str(self.y)], RaggedDtype):
             raise ValueError('y must be a RaggedArray')
 
     def required_columns(self):
-        return self.x + self.y
+        return (self.x,) + (self.y,)
 
     def compute_x_bounds(self, df):
         bounds = self._compute_x_bounds(df[self.x].array.flat_array)
@@ -539,6 +536,41 @@ class LinesAxis1Ragged(_PointLike):
         return extend
 
 
+class _AreaToLineLike(Glyph):
+    """Shared methods between Point and Line"""
+    def __init__(self, x, y, y_stack):
+        self.x = x
+        self.y = y
+        self.y_stack = y_stack
+
+    @property
+    def inputs(self):
+        return (self.x, self.y, self.y_stack)
+
+    def validate(self, in_dshape):
+        if not isreal(in_dshape.measure[str(self.x)]):
+            raise ValueError('x must be real')
+        elif not isreal(in_dshape.measure[str(self.y)]):
+            raise ValueError('y must be real')
+        elif not isreal(in_dshape.measure[str(self.y_stack)]):
+            raise ValueError('y_stack must be real or None')
+
+    @property
+    def x_label(self):
+        return self.x
+
+    @property
+    def y_label(self):
+        return self.y
+
+    def required_columns(self):
+        return self.x, self.y, self.y_stack
+
+    def compute_x_bounds(self, df):
+        bounds = self._compute_x_bounds(df[self.x].values)
+        return self.maybe_expand_bounds(bounds)
+
+
 class AreaToZeroAxis0(_PointLike):
     """A filled area glyph
     The area to be filled is the region from the line defined by ``x`` and
@@ -573,7 +605,7 @@ class AreaToZeroAxis0(_PointLike):
         x_extents = np.nanmin(r[:, 0]), np.nanmax(r[:, 1])
         y_extents = np.nanmin(r[:, 2]), np.nanmax(r[:, 3])
 
-        # Make sure y_extents include 0
+        # Make sure y_extents include zero
         y_extents = min(y_extents[0], 0), max(y_extents[1], 0)
 
         return (self.maybe_expand_bounds(x_extents),
@@ -583,7 +615,7 @@ class AreaToZeroAxis0(_PointLike):
     def _build_extend(self, x_mapper, y_mapper, info, append):
         draw_trapezoid_y = _build_draw_trapezoid_y(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
-        extend_area = _build_extend_area_axis0(
+        extend_area = _build_extend_area_to_zero_axis0(
             draw_trapezoid_y, map_onto_pixel)
         x_name = self.x
         y_name = self.y
@@ -592,12 +624,12 @@ class AreaToZeroAxis0(_PointLike):
             xs = df[x_name].values
             ys = df[y_name].values
             cols = aggs + info(df)
-            extend_area(vt, bounds, xs, ys, np.array([0.0]), plot_start, *cols)
+            extend_area(vt, bounds, xs, ys, plot_start, *cols)
 
         return extend
 
 
-class AreaToLineAxis0(_PointLike):
+class AreaToLineAxis0(_AreaToLineLike):
     """A filled area glyph
     The area to be filled is the region from the line defined by ``x`` and
     ``y[0]`` and the line defined by ``x`` and ``y[1]``.
@@ -610,25 +642,11 @@ class AreaToLineAxis0(_PointLike):
         List or tuple of length two containing the column names of the
         y-coordinates of the two curves that define the area region.
     """
-    @property
-    def y_label(self):
-        # Name by first line
-        return self.y[0]
-
-    def required_columns(self):
-        return (self.x,) + self.y
-
-    def validate(self, in_dshape):
-        if not isreal(in_dshape.measure[str(self.x)]):
-            raise ValueError('x must be real')
-        elif not all([isreal(in_dshape.measure[str(ycol)])
-                      for ycol in self.y]):
-            raise ValueError('y columns must be real')
 
     def compute_y_bounds(self, df):
         # Compute bounds of each curve
-        bounds0 = self._compute_y_bounds(df[self.y[0]].values)
-        bounds1 = self._compute_y_bounds(df[self.y[1]].values)
+        bounds0 = self._compute_y_bounds(df[self.y].values)
+        bounds1 = self._compute_y_bounds(df[self.y_stack].values)
 
         # Combine bounds from the two curves
         bounds = min(bounds0[0], bounds1[0]), max(bounds0[1], bounds1[1])
@@ -641,10 +659,10 @@ class AreaToLineAxis0(_PointLike):
         r = ddf.map_partitions(lambda df: np.array([[
             np.nanmin(df[self.x].values),
             np.nanmax(df[self.x].values),
-            np.nanmin(df[self.y[0]].values),
-            np.nanmax(df[self.y[0]].values),
-            np.nanmin(df[self.y[1]].values),
-            np.nanmax(df[self.y[1]].values)]]
+            np.nanmin(df[self.y].values),
+            np.nanmax(df[self.y].values),
+            np.nanmin(df[self.y_stack].values),
+            np.nanmax(df[self.y_stack].values)]]
         )).compute()
 
         x_extents = np.nanmin(r[:, 0]), np.nanmax(r[:, 1])
@@ -662,18 +680,707 @@ class AreaToLineAxis0(_PointLike):
     def _build_extend(self, x_mapper, y_mapper, info, append):
         draw_trapezoid_y = _build_draw_trapezoid_y(append)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
-        extend_area = _build_extend_area_axis0(
+        extend_area = _build_extend_area_to_line_axis0(
             draw_trapezoid_y, map_onto_pixel)
         x_name = self.x
-        y_names = self.y
+        y_name = self.y
+        y_stack_name = self.y_stack
 
         def extend(aggs, df, vt, bounds, plot_start=True):
             xs = df[x_name].values
-            ys0 = df[y_names[0]].values
-            ys1 = df[y_names[1]].values
+            ys = df[y_name].values
+            ys_stacks = df[y_stack_name].values
 
             cols = aggs + info(df)
-            extend_area(vt, bounds, xs, ys0, ys1, plot_start, *cols)
+            extend_area(vt, bounds, xs, ys, ys_stacks, plot_start, *cols)
+
+        return extend
+
+
+class AreaToZeroAxis0Multi(_PointLike):
+    def validate(self, in_dshape):
+        if not all([isreal(in_dshape.measure[str(xcol)]) for xcol in self.x]):
+            raise ValueError('x columns must be real')
+        elif not all(
+                [isreal(in_dshape.measure[str(ycol)]) for ycol in self.y]):
+            raise ValueError('y columns must be real')
+
+    @property
+    def x_label(self):
+        return 'x'
+
+    @property
+    def y_label(self):
+        return 'y'
+
+    def required_columns(self):
+        return self.x + self.y
+
+    def compute_x_bounds(self, df):
+        bounds_list = [self._compute_x_bounds(df[x].values)
+                       for x in self.x]
+        mins, maxes = zip(*bounds_list)
+        return self.maybe_expand_bounds((min(mins), max(maxes)))
+
+    def compute_y_bounds(self, df):
+        bounds_list = [self._compute_y_bounds(df[y].values)
+                       for y in self.y]
+        mins, maxes = zip(*bounds_list)
+
+        # Make sure min/max range includes zero
+        mn = min(0, min(mins))
+        mx = max(0, max(maxes))
+        return self.maybe_expand_bounds((mn, mx))
+
+    @memoize
+    def compute_bounds_dask(self, ddf):
+
+        r = ddf.map_partitions(lambda df: np.array([[
+            np.nanmin([np.nanmin(df[c].values) for c in self.x]),
+            np.nanmax([np.nanmax(df[c].values) for c in self.x]),
+            np.nanmin([np.nanmin(df[c].values) for c in self.y]),
+            np.nanmax([np.nanmax(df[c].values) for c in self.y])]]
+        )).compute()
+
+        x_extents = np.nanmin(r[:, 0]), np.nanmax(r[:, 1])
+        y_extents = np.nanmin(r[:, 2]), np.nanmax(r[:, 3])
+
+        # Makes sure y_extents include 0
+        y_extents = min(0, y_extents[0]), max(0, y_extents[1])
+
+        return (self.maybe_expand_bounds(x_extents),
+                self.maybe_expand_bounds(y_extents))
+
+    @memoize
+    def _build_extend(self, x_mapper, y_mapper, info, append):
+        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
+        extend_area = _build_extend_area_to_zero_axis0_multi(
+            draw_trapezoid_y, map_onto_pixel)
+        x_names = self.x
+        y_names = self.y
+
+        def extend(aggs, df, vt, bounds, plot_start=True):
+            xs = tuple(df[x_name].values for x_name in x_names)
+            ys = tuple(df[y_name].values for y_name in y_names)
+            cols = aggs + info(df)
+            extend_area(vt, bounds, xs, ys, plot_start, *cols)
+
+        return extend
+
+
+class AreaToLineAxis0Multi(_AreaToLineLike):
+    def validate(self, in_dshape):
+        if not all([isreal(in_dshape.measure[str(xcol)]) for xcol in self.x]):
+            raise ValueError('x columns must be real')
+        elif not all(
+                [isreal(in_dshape.measure[str(ycol)]) for ycol in self.y]):
+            raise ValueError('y columns must be real')
+        elif not all(
+                [isreal(in_dshape.measure[str(ycol)])
+                 for ycol in self.y_stack]):
+            raise ValueError('y_stack columns must be real')
+
+    @property
+    def x_label(self):
+        return 'x'
+
+    @property
+    def y_label(self):
+        return 'y'
+
+    def required_columns(self):
+        return self.x + self.y + self.y_stack
+
+    def compute_x_bounds(self, df):
+        bounds_list = [self._compute_x_bounds(df[x].values)
+                       for x in self.x]
+        mins, maxes = zip(*bounds_list)
+        return self.maybe_expand_bounds((min(mins), max(maxes)))
+
+    def compute_y_bounds(self, df):
+        bounds_list = [self._compute_y_bounds(df[y].values)
+                       for y in self.y + self.y_stack]
+        mins, maxes = zip(*bounds_list)
+
+        return self.maybe_expand_bounds((min(mins), max(maxes)))
+
+    @memoize
+    def compute_bounds_dask(self, ddf):
+
+        r = ddf.map_partitions(lambda df: np.array([[
+            np.nanmin([np.nanmin(df[c].values) for c in self.x]),
+            np.nanmax([np.nanmax(df[c].values) for c in self.x]),
+            np.nanmin([np.nanmin(df[c].values) for c in self.y]),
+            np.nanmax([np.nanmax(df[c].values) for c in self.y]),
+            np.nanmin([np.nanmin(df[c].values) for c in self.y_stack]),
+            np.nanmax([np.nanmax(df[c].values) for c in self.y_stack]),
+        ]]
+        )).compute()
+
+        x_extents = np.nanmin(r[:, 0]), np.nanmax(r[:, 1])
+        y_extents = np.nanmin(r[:, [2, 4]]), np.nanmax(r[:, [3, 5]])
+
+        return (self.maybe_expand_bounds(x_extents),
+                self.maybe_expand_bounds(y_extents))
+
+    @memoize
+    def _build_extend(self, x_mapper, y_mapper, info, append):
+        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
+        extend_area = _build_extend_area_to_line_axis0_multi(
+            draw_trapezoid_y, map_onto_pixel)
+        x_names = self.x
+        y_names = self.y
+        y_stack_names = self.y_stack
+
+        def extend(aggs, df, vt, bounds, plot_start=True):
+            xs = tuple(df[x_name].values for x_name in x_names)
+            ys = tuple(df[y_name].values for y_name in y_names)
+            y_stacks = tuple(df[y_stack_name].values
+                             for y_stack_name in y_stack_names)
+
+            cols = aggs + info(df)
+            extend_area(vt, bounds, xs, ys, y_stacks, plot_start, *cols)
+
+        return extend
+
+
+class AreaToZeroAxis1(_PointLike):
+    def validate(self, in_dshape):
+        if not all([isreal(in_dshape.measure[str(xcol)])
+                    for xcol in self.x]):
+            raise ValueError('x columns must be real')
+        elif not all([isreal(in_dshape.measure[str(ycol)])
+                      for ycol in self.y]):
+            raise ValueError('y columns must be real')
+
+        unique_x_measures = set(in_dshape.measure[str(xcol)]
+                                for xcol in self.x)
+        if len(unique_x_measures) > 1:
+            raise ValueError('x columns must have the same data type')
+
+        unique_y_measures = set(in_dshape.measure[str(ycol)]
+                                for ycol in self.y)
+        if len(unique_y_measures) > 1:
+            raise ValueError('y columns must have the same data type')
+
+    def required_columns(self):
+        return self.x + self.y
+
+    @property
+    def x_label(self):
+        return 'x'
+
+    @property
+    def y_label(self):
+        return 'y'
+
+    def compute_x_bounds(self, df):
+        xs = tuple(df[xlabel] for xlabel in self.x)
+
+        bounds_list = [self._compute_x_bounds(xcol.values) for xcol in xs]
+        mins, maxes = zip(*bounds_list)
+
+        return self.maybe_expand_bounds((min(mins), max(maxes)))
+
+    def compute_y_bounds(self, df):
+        ys = tuple(df[ylabel] for ylabel in self.y)
+
+        bounds_list = [self._compute_y_bounds(ycol.values) for ycol in ys]
+        mins, maxes = zip(*bounds_list)
+
+        # Make sure min/max range includes zero
+        mn = min(0, min(mins))
+        mx = max(0, max(maxes))
+
+        return self.maybe_expand_bounds((mn, mx))
+
+    @memoize
+    def compute_bounds_dask(self, ddf):
+
+        r = ddf.map_partitions(lambda df: np.array([[
+            np.nanmin([np.nanmin(df[c].values) for c in self.x]),
+            np.nanmax([np.nanmax(df[c].values) for c in self.x]),
+            np.nanmin([np.nanmin(df[c].values) for c in self.y]),
+            np.nanmax([np.nanmax(df[c].values) for c in self.y])]]
+        )).compute()
+
+        x_extents = np.nanmin(r[:, 0]), np.nanmax(r[:, 1])
+        y_extents = np.nanmin(r[:, 2]), np.nanmax(r[:, 3])
+
+        # Makes sure y_extents include 0
+        y_extents = min(0, y_extents[0]), max(0, y_extents[1])
+
+        return (self.maybe_expand_bounds(x_extents),
+                self.maybe_expand_bounds(y_extents))
+
+    @memoize
+    def _build_extend(self, x_mapper, y_mapper, info, append):
+        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
+        extend_area = _build_extend_area_to_zero_axis1_none_constant(
+            draw_trapezoid_y, map_onto_pixel)
+
+        x_names = self.x
+        y_names = self.y
+
+        def extend(aggs, df, vt, bounds, plot_start=True):
+            xs = tuple(df[x_name].values for x_name in x_names)
+            ys = tuple(df[y_name].values for y_name in y_names)
+
+            cols = aggs + info(df)
+            # line may be clipped, then mapped to pixels
+            extend_area(vt, bounds, xs, ys, plot_start, *cols)
+
+        return extend
+
+
+class AreaToLineAxis1(_AreaToLineLike):
+    def validate(self, in_dshape):
+        if not all([isreal(in_dshape.measure[str(xcol)])
+                    for xcol in self.x]):
+            raise ValueError('x columns must be real')
+        elif not all([isreal(in_dshape.measure[str(ycol)])
+                      for ycol in self.y]):
+            raise ValueError('y columns must be real')
+        elif not all([isreal(in_dshape.measure[str(ycol)])
+                      for ycol in self.y_stack]):
+            raise ValueError('y_stack columns must be real')
+
+        unique_x_measures = set(in_dshape.measure[str(xcol)]
+                                for xcol in self.x)
+        if len(unique_x_measures) > 1:
+            raise ValueError('x columns must have the same data type')
+
+        unique_y_measures = set(in_dshape.measure[str(ycol)]
+                                for ycol in self.y)
+        if len(unique_y_measures) > 1:
+            raise ValueError('y columns must have the same data type')
+
+        unique_y_stack_measures = set(in_dshape.measure[str(ycol)]
+                                      for ycol in self.y_stack)
+        if len(unique_y_stack_measures) > 1:
+            raise ValueError('y_stack columns must have the same data type')
+
+    def required_columns(self):
+        return self.x + self.y + self.y_stack
+
+    @property
+    def x_label(self):
+        return 'x'
+
+    @property
+    def y_label(self):
+        return 'y'
+
+    def compute_x_bounds(self, df):
+        xs = tuple(df[xlabel] for xlabel in self.x)
+
+        bounds_list = [self._compute_x_bounds(xcol.values) for xcol in xs]
+        mins, maxes = zip(*bounds_list)
+
+        return self.maybe_expand_bounds((min(mins), max(maxes)))
+
+    def compute_y_bounds(self, df):
+        bounds_list = [self._compute_y_bounds(df[y].values)
+                       for y in self.y + self.y_stack]
+        mins, maxes = zip(*bounds_list)
+
+        return self.maybe_expand_bounds((min(mins), max(maxes)))
+
+    @memoize
+    def compute_bounds_dask(self, ddf):
+
+        r = ddf.map_partitions(lambda df: np.array([[
+            np.nanmin([np.nanmin(df[c].values) for c in self.x]),
+            np.nanmax([np.nanmax(df[c].values) for c in self.x]),
+            np.nanmin([np.nanmin(df[c].values) for c in self.y]),
+            np.nanmax([np.nanmax(df[c].values) for c in self.y]),
+            np.nanmin([np.nanmin(df[c].values) for c in self.y_stack]),
+            np.nanmax([np.nanmax(df[c].values) for c in self.y_stack]),
+        ]]
+        )).compute()
+
+        x_extents = np.nanmin(r[:, 0]), np.nanmax(r[:, 1])
+        y_extents = np.nanmin(r[:, [2, 4]]), np.nanmax(r[:, [3, 5]])
+
+        return (self.maybe_expand_bounds(x_extents),
+                self.maybe_expand_bounds(y_extents))
+
+    @memoize
+    def _build_extend(self, x_mapper, y_mapper, info, append):
+        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
+        extend_area = _build_extend_area_to_line_axis1_none_constant(
+            draw_trapezoid_y, map_onto_pixel)
+        x_names = self.x
+        y_names = self.y
+        y_stack_names = self.y_stack
+
+        def extend(aggs, df, vt, bounds, plot_start=True):
+            xs = tuple(df[x_name].values for x_name in x_names)
+            ys = tuple(df[y_name].values for y_name in y_names)
+            y_stacks = tuple(df[y_stack_name].values
+                             for y_stack_name in y_stack_names)
+
+            cols = aggs + info(df)
+            extend_area(vt, bounds, xs, ys, y_stacks, plot_start, *cols)
+
+        return extend
+
+
+class AreaToZeroAxis1XConstant(AreaToZeroAxis1):
+    def validate(self, in_dshape):
+        if not all([isreal(in_dshape.measure[str(ycol)]) for ycol in self.y]):
+            raise ValueError('y columns must be real')
+
+        unique_y_measures = set(in_dshape.measure[str(ycol)]
+                                for ycol in self.y)
+        if len(unique_y_measures) > 1:
+            raise ValueError('y columns must have the same data type')
+
+    def required_columns(self):
+        return self.y
+
+    def compute_x_bounds(self, *args):
+        x_min = np.nanmin(self.x)
+        x_max = np.nanmax(self.x)
+        return self.maybe_expand_bounds((x_min, x_max))
+
+    @memoize
+    def compute_bounds_dask(self, ddf):
+
+        r = ddf.map_partitions(lambda df: np.array([[
+            np.nanmin([np.nanmin(df[c].values) for c in self.y]),
+            np.nanmax([np.nanmax(df[c].values) for c in self.y])]]
+        )).compute()
+
+        y_extents = np.nanmin(r[:, 0]), np.nanmax(r[:, 1])
+
+        return (self.compute_x_bounds(),
+                self.maybe_expand_bounds(y_extents))
+
+    @memoize
+    def _build_extend(self, x_mapper, y_mapper, info, append):
+        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
+        extend_area = _build_extend_area_to_zero_axis1_x_constant(
+            draw_trapezoid_y, map_onto_pixel)
+
+        x_values = self.x
+        y_names = self.y
+
+        def extend(aggs, df, vt, bounds, plot_start=True):
+            ys = tuple(df[y_name].values for y_name in y_names)
+
+            cols = aggs + info(df)
+            # line may be clipped, then mapped to pixels
+            extend_area(vt, bounds, x_values, ys, plot_start, *cols)
+
+        return extend
+
+
+class AreaToLineAxis1XConstant(AreaToLineAxis1):
+    def validate(self, in_dshape):
+        if not all([isreal(in_dshape.measure[str(ycol)])
+                    for ycol in self.y]):
+            raise ValueError('y columns must be real')
+
+        if not all([isreal(in_dshape.measure[str(ycol)])
+                    for ycol in self.y_stack]):
+            raise ValueError('y_stack columns must be real')
+
+        unique_y_measures = set(in_dshape.measure[str(ycol)]
+                                for ycol in self.y)
+        if len(unique_y_measures) > 1:
+            raise ValueError('y columns must have the same data type')
+
+        unique_y_stack_measures = set(in_dshape.measure[str(ycol)]
+                                      for ycol in self.y)
+        if len(unique_y_stack_measures) > 1:
+            raise ValueError('y_stack columns must have the same data type')
+
+    def required_columns(self):
+        return self.y + self.y_stack
+
+    def compute_x_bounds(self, *args):
+        x_min = np.nanmin(self.x)
+        x_max = np.nanmax(self.x)
+        return self.maybe_expand_bounds((x_min, x_max))
+
+    @memoize
+    def compute_bounds_dask(self, ddf):
+
+        r = ddf.map_partitions(lambda df: np.array([[
+            np.nanmin([np.nanmin(df[c].values) for c in self.y]),
+            np.nanmax([np.nanmax(df[c].values) for c in self.y]),
+            np.nanmin([np.nanmin(df[c].values) for c in self.y_stack]),
+            np.nanmax([np.nanmax(df[c].values) for c in self.y_stack]),
+        ]]
+        )).compute()
+
+        y_extents = np.nanmin(r[:, [0, 2]]), np.nanmax(r[:, [1, 3]])
+
+        return (self.compute_x_bounds(),
+                self.maybe_expand_bounds(y_extents))
+
+    @memoize
+    def _build_extend(self, x_mapper, y_mapper, info, append):
+        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
+        extend_area = _build_extend_area_to_line_axis1_x_constant(
+            draw_trapezoid_y, map_onto_pixel)
+
+        x_values = self.x
+        y_names = self.y
+        y_stack_names = self.y_stack
+
+        def extend(aggs, df, vt, bounds, plot_start=True):
+            ys = tuple(df[y_name].values for y_name in y_names)
+            y_stacks = tuple(df[y_stack_name].values
+                             for y_stack_name in y_stack_names)
+
+            cols = aggs + info(df)
+            extend_area(vt, bounds, x_values, ys, y_stacks, plot_start, *cols)
+
+        return extend
+
+
+class AreaToZeroAxis1YConstant(AreaToZeroAxis1):
+    def validate(self, in_dshape):
+        if not all([isreal(in_dshape.measure[str(xcol)]) for xcol in self.x]):
+            raise ValueError('x columns must be real')
+
+        unique_x_measures = set(in_dshape.measure[str(xcol)]
+                                for xcol in self.x)
+        if len(unique_x_measures) > 1:
+            raise ValueError('x columns must have the same data type')
+
+    def required_columns(self):
+        return self.x
+
+    def compute_y_bounds(self, *args):
+        y_min = np.nanmin(self.y)
+        y_max = np.nanmax(self.y)
+        return self.maybe_expand_bounds((y_min, y_max))
+
+    @memoize
+    def compute_bounds_dask(self, ddf):
+
+        r = ddf.map_partitions(lambda df: np.array([[
+            np.nanmin([np.nanmin(df[c].values) for c in self.x]),
+            np.nanmax([np.nanmax(df[c].values) for c in self.x])]]
+        )).compute()
+
+        x_extents = np.nanmin(r[:, 0]), np.nanmax(r[:, 1])
+
+        return (self.maybe_expand_bounds(x_extents),
+                self.compute_y_bounds())
+
+    @memoize
+    def _build_extend(self, x_mapper, y_mapper, info, append):
+        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
+        extend_area = _build_extend_area_to_zero_axis1_y_constant(
+            draw_trapezoid_y, map_onto_pixel)
+
+        x_names = self.x
+        y_values = self.y
+
+        def extend(aggs, df, vt, bounds, plot_start=True):
+            xs = tuple(df[x_name].values for x_name in x_names)
+
+            cols = aggs + info(df)
+            # line may be clipped, then mapped to pixels
+            extend_area(vt, bounds, xs, y_values, plot_start, *cols)
+
+        return extend
+
+
+class AreaToLineAxis1YConstant(AreaToLineAxis1):
+    def validate(self, in_dshape):
+        if not all([isreal(in_dshape.measure[str(xcol)]) for xcol in self.x]):
+            raise ValueError('x columns must be real')
+
+        unique_x_measures = set(in_dshape.measure[str(xcol)]
+                                for xcol in self.x)
+        if len(unique_x_measures) > 1:
+            raise ValueError('x columns must have the same data type')
+
+    def required_columns(self):
+        return self.x
+
+    def compute_y_bounds(self, *args):
+        y_min = min(np.nanmin(self.y), np.nanmin(self.y_stack))
+        y_max = max(np.nanmax(self.y), np.nanmax(self.y_stack))
+        return self.maybe_expand_bounds((y_min, y_max))
+
+    @memoize
+    def compute_bounds_dask(self, ddf):
+
+        r = ddf.map_partitions(lambda df: np.array([[
+            np.nanmin([np.nanmin(df[c].values) for c in self.x]),
+            np.nanmax([np.nanmax(df[c].values) for c in self.x])]]
+        )).compute()
+
+        x_extents = np.nanmin(r[:, 0]), np.nanmax(r[:, 1])
+
+        return (self.maybe_expand_bounds(x_extents),
+                self.compute_y_bounds())
+
+    @memoize
+    def _build_extend(self, x_mapper, y_mapper, info, append):
+        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
+        extend_area = _build_extend_area_to_line_axis1_y_constant(
+            draw_trapezoid_y, map_onto_pixel)
+        x_names = self.x
+        y_values = self.y
+        y_stack_values = self.y_stack
+
+        def extend(aggs, df, vt, bounds, plot_start=True):
+            xs = tuple(df[x_name].values for x_name in x_names)
+
+            cols = aggs + info(df)
+            extend_area(
+                vt, bounds, xs, y_values, y_stack_values, plot_start, *cols)
+
+        return extend
+
+
+class AreaToZeroAxis1Ragged(_PointLike):
+    def validate(self, in_dshape):
+        try:
+            from datashader.datatypes import RaggedDtype
+        except ImportError:
+            RaggedDtype = type(None)
+
+        if not isinstance(in_dshape[str(self.x)], RaggedDtype):
+            raise ValueError('x must be a RaggedArray')
+        elif not isinstance(in_dshape[str(self.y)], RaggedDtype):
+            raise ValueError('y must be a RaggedArray')
+
+    def required_columns(self):
+        return self.x, self.y
+
+    def compute_x_bounds(self, df):
+        bounds = self._compute_x_bounds(df[self.x].array.flat_array)
+        return self.maybe_expand_bounds(bounds)
+
+    def compute_y_bounds(self, df):
+        bounds = self._compute_y_bounds(df[self.y].array.flat_array)
+
+        # Make sure bounds include zero
+        bounds = min(bounds[0], 0), max(bounds[1], 0)
+
+        return self.maybe_expand_bounds(bounds)
+
+    @memoize
+    def compute_bounds_dask(self, ddf):
+
+        r = ddf.map_partitions(lambda df: np.array([[
+            np.nanmin(df[self.x].array.flat_array),
+            np.nanmax(df[self.x].array.flat_array),
+            np.nanmin(df[self.y].array.flat_array),
+            np.nanmax(df[self.y].array.flat_array)]]
+        )).compute()
+
+        x_extents = np.nanmin(r[:, 0]), np.nanmax(r[:, 1])
+        y_extents = np.nanmin(r[:, 2]), np.nanmax(r[:, 3])
+
+        # Make sure y_extents include 0
+        y_extents = min(y_extents[0], 0), max(y_extents[1], 0)
+
+        return (self.maybe_expand_bounds(x_extents),
+                self.maybe_expand_bounds(y_extents))
+
+    @memoize
+    def _build_extend(self, x_mapper, y_mapper, info, append):
+        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
+        extend_area = _build_extend_area_to_zero_axis1_ragged(
+            draw_trapezoid_y, map_onto_pixel)
+        x_name = self.x
+        y_name = self.y
+
+        def extend(aggs, df, vt, bounds, plot_start=True):
+            xs = df[x_name].values
+            ys = df[y_name].values
+            cols = aggs + info(df)
+            extend_area(vt, bounds, xs, ys, plot_start, *cols)
+
+        return extend
+
+
+class AreaToLineAxis1Ragged(_AreaToLineLike):
+    def validate(self, in_dshape):
+        try:
+            from datashader.datatypes import RaggedDtype
+        except ImportError:
+            RaggedDtype = type(None)
+
+        if not isinstance(in_dshape[str(self.x)], RaggedDtype):
+            raise ValueError('x must be a RaggedArray')
+        elif not isinstance(in_dshape[str(self.y)], RaggedDtype):
+            raise ValueError('y must be a RaggedArray')
+        elif not isinstance(in_dshape[str(self.y_stack)], RaggedDtype):
+            raise ValueError('y_stack must be a RaggedArray')
+
+    def required_columns(self):
+        return self.x, self.y, self.y_stack
+
+    def compute_x_bounds(self, df):
+        bounds = self._compute_x_bounds(df[self.x].array.flat_array)
+        return self.maybe_expand_bounds(bounds)
+
+    def compute_y_bounds(self, df):
+        bounds_y = self._compute_y_bounds(df[self.y].array.flat_array)
+        bounds_y_stack = self._compute_y_bounds(
+            df[self.y_stack].array.flat_array)
+
+        # Make sure bounds include zero
+        bounds = (min(bounds_y[0], bounds_y_stack[0], 0),
+                  max(bounds_y[1], bounds_y_stack[1], 0))
+
+        return self.maybe_expand_bounds(bounds)
+
+    @memoize
+    def compute_bounds_dask(self, ddf):
+
+        r = ddf.map_partitions(lambda df: np.array([[
+            np.nanmin(df[self.x].array.flat_array),
+            np.nanmax(df[self.x].array.flat_array),
+            np.nanmin(df[self.y].array.flat_array),
+            np.nanmax(df[self.y].array.flat_array),
+            np.nanmin(df[self.y_stack].array.flat_array),
+            np.nanmax(df[self.y_stack].array.flat_array),
+        ]]
+        )).compute()
+
+        x_extents = np.nanmin(r[:, 0]), np.nanmax(r[:, 1])
+        y_extents = np.nanmin(r[:, [2, 4]]), np.nanmax(r[:, [3, 5]])
+
+        return (self.maybe_expand_bounds(x_extents),
+                self.maybe_expand_bounds(y_extents))
+
+    @memoize
+    def _build_extend(self, x_mapper, y_mapper, info, append):
+        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
+        extend_area = _build_extend_area_to_line_axis1_ragged(
+            draw_trapezoid_y, map_onto_pixel)
+        x_name = self.x
+        y_name = self.y
+        y_stack_name = self.y_stack
+
+        def extend(aggs, df, vt, bounds, plot_start=True):
+            xs = df[x_name].values
+            ys = df[y_name].values
+            y_stacks = df[y_stack_name].values
+
+            cols = aggs + info(df)
+            extend_area(vt, bounds, xs, ys, y_stacks, plot_start, *cols)
 
         return extend
 
@@ -1352,7 +2059,7 @@ def _build_extend_line_axis1_ragged(draw_line, map_onto_pixel):
                                     plot_start,
                                     *aggs_and_cols)
 
-    # @ngjit
+    @ngjit
     def perform_extend_lines_ragged(vt,
                                     bounds,
                                     x_start_indices,
@@ -1449,7 +2156,7 @@ def _build_extend_area_to_zero_axis0(draw_trapezoid_y, map_onto_pixel):
     return extend_area
 
 
-def _build_extend_area_axis0(draw_trapezoid_y, map_onto_pixel):
+def _build_extend_area_to_line_axis0(draw_trapezoid_y, map_onto_pixel):
     @ngjit
     def extend_area(vt, bounds, xs, ys0, ys1, plot_start, *aggs_and_cols):
         """Aggregate filled area between the line formed by
@@ -1486,6 +2193,538 @@ def _build_extend_area_axis0(draw_trapezoid_y, map_onto_pixel):
             i += 1
 
     return extend_area
+
+
+def _build_extend_area_to_zero_axis0_multi(draw_trapezoid_y, map_onto_pixel):
+    @ngjit
+    def extend_area(vt, bounds, xs, ys, plot_start, *aggs_and_cols):
+        """Aggregate filled area along a line formed by
+        ``xs`` and ``ys``, filled to the y=0 line"""
+
+        stacked = False
+        xmaxi, ymaxi = map_onto_pixel(vt, bounds, bounds[1], bounds[3])
+
+        nrows = xs[0].shape[0]
+        ncols = len(xs)
+
+        orig_plot_start = plot_start
+
+        j = 0
+        while j < ncols:
+            plot_start = orig_plot_start
+            i = 0
+            while i < nrows - 1:
+                x0 = xs[j][i]
+                x1 = xs[j][i + 1]
+
+                y0 = ys[j][i]
+                y1 = 0.0
+                y2 = 0.0
+                y3 = ys[j][i + 1]
+
+                x0, x1, y0, y1, y2, y3, skip, clipped, plot_start = \
+                    _skip_or_clip_trapezoid_y(
+                        x0, x1, y0, y1, y2, y3, bounds, plot_start)
+
+                if not skip:
+                    x0i, y0i = map_onto_pixel(vt, bounds, x0, y0)
+                    _, y1i = map_onto_pixel(vt, bounds, x0, y1)
+                    y2i = y1i
+                    x1i, y3i = map_onto_pixel(vt, bounds, x1, y3)
+
+                    draw_trapezoid_y(x0i, x1i, y0i, y1i, y2i, y3i, xmaxi, ymaxi,
+                                     i, plot_start, clipped, stacked,
+                                     *aggs_and_cols)
+                    plot_start = False
+                i += 1
+            j += 1
+
+    return extend_area
+
+
+def _build_extend_area_to_line_axis0_multi(draw_trapezoid_y, map_onto_pixel):
+    @ngjit
+    def extend_area(vt, bounds, xs, ys0, ys1, plot_start, *aggs_and_cols):
+        """Aggregate filled area along a line formed by
+        ``xs`` and ``ys``, filled to the y=0 line"""
+
+        stacked = True
+        xmaxi, ymaxi = map_onto_pixel(vt, bounds, bounds[1], bounds[3])
+
+        nrows = xs[0].shape[0]
+        ncols = len(xs)
+        orig_plot_start = plot_start
+
+        j = 0
+        while j < ncols:
+            plot_start = orig_plot_start
+            i = 0
+            while i < nrows - 1:
+                x0 = xs[j][i]
+                x1 = xs[j][i + 1]
+
+                y0 = ys0[j][i]
+                y1 = ys1[j][i]
+                y2 = ys1[j][i + 1]
+                y3 = ys0[j][i + 1]
+
+                x0, x1, y0, y1, y2, y3, skip, clipped, plot_start = \
+                    _skip_or_clip_trapezoid_y(
+                        x0, x1, y0, y1, y2, y3, bounds, plot_start)
+
+                if not skip:
+                    x0i, y0i = map_onto_pixel(vt, bounds, x0, y0)
+                    _, y1i = map_onto_pixel(vt, bounds, x0, y1)
+                    y2i = y1i
+                    x1i, y3i = map_onto_pixel(vt, bounds, x1, y3)
+
+                    draw_trapezoid_y(x0i, x1i, y0i, y1i, y2i, y3i, xmaxi,
+                                     ymaxi,
+                                     i, plot_start, clipped, stacked,
+                                     *aggs_and_cols)
+                    plot_start = False
+                i += 1
+            j += 1
+
+    return extend_area
+
+
+def _build_extend_area_to_zero_axis1_none_constant(draw_trapezoid_y, map_onto_pixel):
+    @ngjit
+    def extend_area(vt, bounds, xs, ys, plot_start, *aggs_and_cols):
+        """Aggregate filled area along a line formed by
+        ``xs`` and ``ys``, filled to the y=0 line"""
+
+        stacked = False
+        xmaxi, ymaxi = map_onto_pixel(vt, bounds, bounds[1], bounds[3])
+
+        nrows = xs[0].shape[0]
+        ncols = len(xs)
+
+        i = 0
+        while i < nrows:
+            plot_start = True
+            j = 0
+            while j < ncols - 1:
+                x0 = xs[j][i]
+                x1 = xs[j + 1][i]
+
+                y0 = ys[j][i]
+                y1 = 0.0
+                y2 = 0.0
+                y3 = ys[j + 1][i]
+
+                x0, x1, y0, y1, y2, y3, skip, clipped, plot_start = \
+                    _skip_or_clip_trapezoid_y(
+                        x0, x1, y0, y1, y2, y3, bounds, plot_start)
+
+                if not skip:
+                    x0i, y0i = map_onto_pixel(vt, bounds, x0, y0)
+                    _, y1i = map_onto_pixel(vt, bounds, x0, y1)
+                    y2i = y1i
+                    x1i, y3i = map_onto_pixel(vt, bounds, x1, y3)
+
+                    draw_trapezoid_y(x0i, x1i, y0i, y1i, y2i, y3i, xmaxi, ymaxi,
+                                     i, plot_start, clipped, stacked,
+                                     *aggs_and_cols)
+                    plot_start = False
+                j += 1
+            i += 1
+
+    return extend_area
+
+
+def _build_extend_area_to_line_axis1_none_constant(draw_trapezoid_y, map_onto_pixel):
+    @ngjit
+    def extend_area(vt, bounds, xs, ys0, ys1, plot_start, *aggs_and_cols):
+        """Aggregate filled area along a line formed by
+        ``xs`` and ``ys``, filled to the y=0 line"""
+
+        stacked = True
+        xmaxi, ymaxi = map_onto_pixel(vt, bounds, bounds[1], bounds[3])
+
+        nrows = xs[0].shape[0]
+        ncols = len(xs)
+
+        i = 0
+        while i < nrows:
+            plot_start = True
+            j = 0
+            while j < ncols - 1:
+                x0 = xs[j][i]
+                x1 = xs[j + 1][i]
+
+                y0 = ys0[j][i]
+                y1 = ys1[j][i]
+                y2 = ys1[j + 1][i]
+                y3 = ys0[j + 1][i]
+
+                x0, x1, y0, y1, y2, y3, skip, clipped, plot_start = \
+                    _skip_or_clip_trapezoid_y(
+                        x0, x1, y0, y1, y2, y3, bounds, plot_start)
+
+                if not skip:
+                    x0i, y0i = map_onto_pixel(vt, bounds, x0, y0)
+                    _, y1i = map_onto_pixel(vt, bounds, x0, y1)
+                    y2i = y1i
+                    x1i, y3i = map_onto_pixel(vt, bounds, x1, y3)
+
+                    draw_trapezoid_y(x0i, x1i, y0i, y1i, y2i, y3i, xmaxi, ymaxi,
+                                     i, plot_start, clipped, stacked,
+                                     *aggs_and_cols)
+                    plot_start = False
+                j += 1
+            i += 1
+
+    return extend_area
+
+
+def _build_extend_area_to_zero_axis1_x_constant(draw_trapezoid_y, map_onto_pixel):
+    @ngjit
+    def extend_area(vt, bounds, xs, ys, plot_start, *aggs_and_cols):
+        """Aggregate filled area along a line formed by
+        ``xs`` and ``ys``, filled to the y=0 line"""
+
+        stacked = False
+        xmaxi, ymaxi = map_onto_pixel(vt, bounds, bounds[1], bounds[3])
+
+        nrows = ys[0].shape[0]
+        ncols = len(ys)
+
+        i = 0
+        while i < nrows:
+            plot_start = True
+            j = 0
+            while j < ncols - 1:
+                x0 = xs[j]
+                x1 = xs[j + 1]
+
+                y0 = ys[j][i]
+                y1 = 0.0
+                y2 = 0.0
+                y3 = ys[j + 1][i]
+
+                x0, x1, y0, y1, y2, y3, skip, clipped, plot_start = \
+                    _skip_or_clip_trapezoid_y(
+                        x0, x1, y0, y1, y2, y3, bounds, plot_start)
+
+                if not skip:
+                    x0i, y0i = map_onto_pixel(vt, bounds, x0, y0)
+                    _, y1i = map_onto_pixel(vt, bounds, x0, y1)
+                    y2i = y1i
+                    x1i, y3i = map_onto_pixel(vt, bounds, x1, y3)
+
+                    draw_trapezoid_y(x0i, x1i, y0i, y1i, y2i, y3i, xmaxi, ymaxi,
+                                     i, plot_start, clipped, stacked,
+                                     *aggs_and_cols)
+                    plot_start = False
+                j += 1
+            i += 1
+
+    return extend_area
+
+
+def _build_extend_area_to_line_axis1_x_constant(draw_trapezoid_y, map_onto_pixel):
+    @ngjit
+    def extend_area(vt, bounds, xs, ys0, ys1, plot_start, *aggs_and_cols):
+        """Aggregate filled area along a line formed by
+        ``xs`` and ``ys``, filled to the y=0 line"""
+
+        stacked = False
+        xmaxi, ymaxi = map_onto_pixel(vt, bounds, bounds[1], bounds[3])
+
+        nrows = ys0[0].shape[0]
+        ncols = len(ys0)
+
+        i = 0
+        while i < nrows:
+            plot_start = True
+            j = 0
+            while j < ncols - 1:
+                x0 = xs[j]
+                x1 = xs[j + 1]
+
+                y0 = ys0[j][i]
+                y1 = ys1[j][i]
+                y2 = ys1[j + 1][i]
+                y3 = ys0[j + 1][i]
+
+                x0, x1, y0, y1, y2, y3, skip, clipped, plot_start = \
+                    _skip_or_clip_trapezoid_y(
+                        x0, x1, y0, y1, y2, y3, bounds, plot_start)
+
+                if not skip:
+                    x0i, y0i = map_onto_pixel(vt, bounds, x0, y0)
+                    _, y1i = map_onto_pixel(vt, bounds, x0, y1)
+                    y2i = y1i
+                    x1i, y3i = map_onto_pixel(vt, bounds, x1, y3)
+
+                    draw_trapezoid_y(x0i, x1i, y0i, y1i, y2i, y3i, xmaxi, ymaxi,
+                                     i, plot_start, clipped, stacked,
+                                     *aggs_and_cols)
+                    plot_start = False
+                j += 1
+            i += 1
+
+    return extend_area
+
+
+def _build_extend_area_to_zero_axis1_y_constant(draw_trapezoid_y, map_onto_pixel):
+    @ngjit
+    def extend_area(vt, bounds, xs, ys, plot_start, *aggs_and_cols):
+        """Aggregate filled area along a line formed by
+        ``xs`` and ``ys``, filled to the y=0 line"""
+
+        stacked = False
+        xmaxi, ymaxi = map_onto_pixel(vt, bounds, bounds[1], bounds[3])
+
+        nrows = xs[0].shape[0]
+        ncols = len(xs)
+
+        i = 0
+        while i < nrows:
+            plot_start = True
+            j = 0
+            while j < ncols - 1:
+                x0 = xs[j][i]
+                x1 = xs[j + 1][i]
+
+                y0 = ys[j]
+                y1 = 0.0
+                y2 = 0.0
+                y3 = ys[j + 1]
+
+                x0, x1, y0, y1, y2, y3, skip, clipped, plot_start = \
+                    _skip_or_clip_trapezoid_y(
+                        x0, x1, y0, y1, y2, y3, bounds, plot_start)
+
+                if not skip:
+                    x0i, y0i = map_onto_pixel(vt, bounds, x0, y0)
+                    _, y1i = map_onto_pixel(vt, bounds, x0, y1)
+                    y2i = y1i
+                    x1i, y3i = map_onto_pixel(vt, bounds, x1, y3)
+
+                    draw_trapezoid_y(x0i, x1i, y0i, y1i, y2i, y3i, xmaxi, ymaxi,
+                                     i, plot_start, clipped, stacked,
+                                     *aggs_and_cols)
+                    plot_start = False
+                j += 1
+            i += 1
+
+    return extend_area
+
+
+def _build_extend_area_to_line_axis1_y_constant(draw_trapezoid_y, map_onto_pixel):
+    @ngjit
+    def extend_area(vt, bounds, xs, ys0, ys1, plot_start, *aggs_and_cols):
+        """Aggregate filled area along a line formed by
+        ``xs`` and ``ys``, filled to the y=0 line"""
+
+        stacked = True
+        xmaxi, ymaxi = map_onto_pixel(vt, bounds, bounds[1], bounds[3])
+
+        nrows = xs[0].shape[0]
+        ncols = len(xs)
+
+        i = 0
+        while i < nrows:
+            plot_start = True
+            j = 0
+            while j < ncols - 1:
+                x0 = xs[j][i]
+                x1 = xs[j + 1][i]
+
+                y0 = ys0[j]
+                y1 = ys1[j]
+                y2 = ys1[j + 1]
+                y3 = ys0[j + 1]
+
+                x0, x1, y0, y1, y2, y3, skip, clipped, plot_start = \
+                    _skip_or_clip_trapezoid_y(
+                        x0, x1, y0, y1, y2, y3, bounds, plot_start)
+
+                if not skip:
+                    x0i, y0i = map_onto_pixel(vt, bounds, x0, y0)
+                    _, y1i = map_onto_pixel(vt, bounds, x0, y1)
+                    y2i = y1i
+                    x1i, y3i = map_onto_pixel(vt, bounds, x1, y3)
+
+                    draw_trapezoid_y(x0i, x1i, y0i, y1i, y2i, y3i, xmaxi, ymaxi,
+                                     i, plot_start, clipped, stacked,
+                                     *aggs_and_cols)
+                    plot_start = False
+                j += 1
+            i += 1
+
+    return extend_area
+
+
+def _build_extend_area_to_zero_axis1_ragged(draw_trapezoid_y, map_onto_pixel):
+
+    def extend_line(vt, bounds, xs, ys, plot_start, *aggs_and_cols):
+        x_start_indices = xs.start_indices
+        x_flat_array = xs.flat_array
+
+        y_start_indices = ys.start_indices
+        y_flat_array = ys.flat_array
+
+        perform_extend_area_to_zero_axis1_ragged(
+            vt, bounds, x_start_indices, x_flat_array,
+            y_start_indices, y_flat_array, plot_start, *aggs_and_cols)
+
+    @ngjit
+    def perform_extend_area_to_zero_axis1_ragged(
+            vt, bounds, x_start_indices, x_flat_array,
+            y_start_indices, y_flat_array, plot_start, *aggs_and_cols):
+
+        stacked = False
+        xmaxi, ymaxi = map_onto_pixel(vt, bounds, bounds[1], bounds[3])
+
+        nrows = len(x_start_indices)
+        x_flat_len = len(x_flat_array)
+        y_flat_len = len(y_flat_array)
+
+        i = 0
+        while i < nrows:
+            plot_start = True
+
+            # Get x index range
+            x_start_index = x_start_indices[i]
+            x_stop_index = (x_start_indices[i + 1]
+                            if i < nrows - 1
+                            else x_flat_len)
+
+            # Get y index range
+            y_start_index = y_start_indices[i]
+            y_stop_index = (y_start_indices[i + 1]
+                            if i < nrows - 1
+                            else y_flat_len)
+
+            # Find line segment length as shorter of the two segments
+            segment_len = min(x_stop_index - x_start_index,
+                              y_stop_index - y_start_index)
+
+            j = 0
+            while j < segment_len - 1:
+
+                x0 = x_flat_array[x_start_index + j]
+                x1 = x_flat_array[x_start_index + j + 1]
+
+                y0 = y_flat_array[y_start_index + j]
+                y1 = 0.0
+                y2 = 0.0
+                y3 = y_flat_array[y_start_index + j + 1]
+
+                x0, x1, y0, y1, y2, y3, skip, clipped, plot_start = \
+                    _skip_or_clip_trapezoid_y(
+                        x0, x1, y0, y1, y2, y3, bounds, plot_start)
+
+                if not skip:
+                    x0i, y0i = map_onto_pixel(vt, bounds, x0, y0)
+                    _, y1i = map_onto_pixel(vt, bounds, x0, y1)
+                    y2i = y1i
+                    x1i, y3i = map_onto_pixel(vt, bounds, x1, y3)
+
+                    draw_trapezoid_y(
+                        x0i, x1i, y0i, y1i, y2i, y3i, xmaxi, ymaxi,
+                        i, plot_start, clipped, stacked, *aggs_and_cols)
+
+                    plot_start = False
+
+                j += 1
+            i += 1
+
+    return extend_line
+
+
+def _build_extend_area_to_line_axis1_ragged(draw_trapezoid_y, map_onto_pixel):
+
+    def extend_line(vt, bounds, xs, ys0, ys1, plot_start, *aggs_and_cols):
+        x_start_indices = xs.start_indices
+        x_flat_array = xs.flat_array
+
+        y0_start_indices = ys0.start_indices
+        y0_flat_array = ys0.flat_array
+
+        y1_start_indices = ys1.start_indices
+        y1_flat_array = ys1.flat_array
+
+        perform_extend_area_to_line_axis1_ragged(
+            vt, bounds, x_start_indices, x_flat_array,
+            y0_start_indices, y0_flat_array, y1_start_indices, y1_flat_array,
+            plot_start, *aggs_and_cols)
+
+    @ngjit
+    def perform_extend_area_to_line_axis1_ragged(
+            vt, bounds, x_start_indices, x_flat_array,
+            y0_start_indices, y0_flat_array, y1_start_indices, y1_flat_array,
+            plot_start, *aggs_and_cols):
+
+        stacked = True
+        xmaxi, ymaxi = map_onto_pixel(vt, bounds, bounds[1], bounds[3])
+
+        nrows = len(x_start_indices)
+        x_flat_len = len(x_flat_array)
+        y0_flat_len = len(y0_flat_array)
+        y1_flat_len = len(y1_flat_array)
+
+        i = 0
+        while i < nrows:
+            plot_start = True
+
+            # Get x index range
+            x_start_index = x_start_indices[i]
+            x_stop_index = (x_start_indices[i + 1]
+                            if i < nrows - 1
+                            else x_flat_len)
+
+            # Get y index range
+            y0_start_index = y0_start_indices[i]
+            y0_stop_index = (y0_start_indices[i + 1]
+                             if i < nrows - 1
+                             else y0_flat_len)
+
+            y1_start_index = y1_start_indices[i]
+            y1_stop_index = (y1_start_indices[i + 1]
+                             if i < nrows - 1
+                             else y1_flat_len)
+
+            # Find line segment length as shorter of the two segments
+            segment_len = min(x_stop_index - x_start_index,
+                              y0_stop_index - y0_start_index,
+                              y1_stop_index - y1_start_index)
+
+            j = 0
+            while j < segment_len - 1:
+
+                x0 = x_flat_array[x_start_index + j]
+                x1 = x_flat_array[x_start_index + j + 1]
+
+                y0 = y0_flat_array[y0_start_index + j]
+                y1 = y1_flat_array[y1_start_index + j]
+                y2 = y1_flat_array[y1_start_index + j + 1]
+                y3 = y0_flat_array[y0_start_index + j + 1]
+
+                x0, x1, y0, y1, y2, y3, skip, clipped, plot_start = \
+                    _skip_or_clip_trapezoid_y(
+                        x0, x1, y0, y1, y2, y3, bounds, plot_start)
+
+                if not skip:
+                    x0i, y0i = map_onto_pixel(vt, bounds, x0, y0)
+                    _, y1i = map_onto_pixel(vt, bounds, x0, y1)
+                    y2i = y1i
+                    x1i, y3i = map_onto_pixel(vt, bounds, x1, y3)
+
+                    draw_trapezoid_y(
+                        x0i, x1i, y0i, y1i, y2i, y3i, xmaxi, ymaxi,
+                        i, plot_start, clipped, stacked, *aggs_and_cols)
+
+                    plot_start = False
+
+                j += 1
+            i += 1
+
+    return extend_line
 
 
 def _build_draw_triangle(append):

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -2275,7 +2275,7 @@ def _build_extend_area_to_line_axis0_multi(draw_trapezoid_y, map_onto_pixel):
                 if not skip:
                     x0i, y0i = map_onto_pixel(vt, bounds, x0, y0)
                     _, y1i = map_onto_pixel(vt, bounds, x0, y1)
-                    y2i = y1i
+                    _, y2i = map_onto_pixel(vt, bounds, x1, y2)
                     x1i, y3i = map_onto_pixel(vt, bounds, x1, y3)
 
                     draw_trapezoid_y(x0i, x1i, y0i, y1i, y2i, y3i, xmaxi,
@@ -2366,7 +2366,7 @@ def _build_extend_area_to_line_axis1_none_constant(draw_trapezoid_y, map_onto_pi
                 if not skip:
                     x0i, y0i = map_onto_pixel(vt, bounds, x0, y0)
                     _, y1i = map_onto_pixel(vt, bounds, x0, y1)
-                    y2i = y1i
+                    _, y2i = map_onto_pixel(vt, bounds, x1, y2)
                     x1i, y3i = map_onto_pixel(vt, bounds, x1, y3)
 
                     draw_trapezoid_y(x0i, x1i, y0i, y1i, y2i, y3i, xmaxi, ymaxi,
@@ -2456,7 +2456,7 @@ def _build_extend_area_to_line_axis1_x_constant(draw_trapezoid_y, map_onto_pixel
                 if not skip:
                     x0i, y0i = map_onto_pixel(vt, bounds, x0, y0)
                     _, y1i = map_onto_pixel(vt, bounds, x0, y1)
-                    y2i = y1i
+                    _, y2i = map_onto_pixel(vt, bounds, x1, y2)
                     x1i, y3i = map_onto_pixel(vt, bounds, x1, y3)
 
                     draw_trapezoid_y(x0i, x1i, y0i, y1i, y2i, y3i, xmaxi, ymaxi,
@@ -2546,7 +2546,7 @@ def _build_extend_area_to_line_axis1_y_constant(draw_trapezoid_y, map_onto_pixel
                 if not skip:
                     x0i, y0i = map_onto_pixel(vt, bounds, x0, y0)
                     _, y1i = map_onto_pixel(vt, bounds, x0, y1)
-                    y2i = y1i
+                    _, y2i = map_onto_pixel(vt, bounds, x1, y2)
                     x1i, y3i = map_onto_pixel(vt, bounds, x1, y3)
 
                     draw_trapezoid_y(x0i, x1i, y0i, y1i, y2i, y3i, xmaxi, ymaxi,
@@ -2712,7 +2712,7 @@ def _build_extend_area_to_line_axis1_ragged(draw_trapezoid_y, map_onto_pixel):
                 if not skip:
                     x0i, y0i = map_onto_pixel(vt, bounds, x0, y0)
                     _, y1i = map_onto_pixel(vt, bounds, x0, y1)
-                    y2i = y1i
+                    _, y2i = map_onto_pixel(vt, bounds, x1, y2)
                     x1i, y3i = map_onto_pixel(vt, bounds, x1, y3)
 
                     draw_trapezoid_y(

--- a/datashader/glyphs.py
+++ b/datashader/glyphs.py
@@ -926,7 +926,7 @@ def _build_draw_trapezoid_y(append):
                 y = y_start
                 iy = (y_start < y_stop) - (y_stop < y_start)
 
-                if not stacked:
+                if not stacked and -1 <= y_stop + iy <= ymaxi + 1:
                     # If not stacking, include bin on line from
                     # (x0, y1) to (x1, y2), otherwise leave it out
                     y_stop += iy
@@ -953,7 +953,7 @@ def _build_draw_trapezoid_y(append):
                 y = y_start
                 iy = (y_start < y_stop) - (y_stop < y_start)
 
-                if not stacked:
+                if not stacked and -1 <= y_stop + iy <= ymaxi + 1:
                     # If not stacking, include bin on line from
                     # (x0, y1) to (x1, y2), otherwise leave it
                     y_stop += iy
@@ -1022,7 +1022,7 @@ def _build_draw_trapezoid_y(append):
                 y = y_start
                 iy = (y_start < y_stop) - (y_stop < y_start)
 
-                if not stacked:
+                if not stacked and -1 <= y_stop + iy <= ymaxi + 1:
                     # If not stacking, aggregate bin on line from
                     # (x0, y1) to (x1, y2), otherwise leave it out
                     y_stop += iy

--- a/datashader/pandas.py
+++ b/datashader/pandas.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 from .core import bypixel
 from .compiler import compile_components
-from .glyphs import _PointLike
+from .glyphs import _PointLike, _AreaToLineLike
 from .utils import Dispatcher
 
 __all__ = ()
@@ -19,6 +19,7 @@ glyph_dispatch = Dispatcher()
 
 
 @glyph_dispatch.register(_PointLike)
+@glyph_dispatch.register(_AreaToLineLike)
 def pointlike(glyph, df, schema, canvas, summary):
     create, info, append, _, finalize = compile_components(summary, schema, glyph)
     x_mapper = canvas.x_axis.mapper

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -569,7 +569,7 @@ def test_area_to_zero_autorange():
     assert_eq(agg, out)
 
 
-def test_area_to_zero_autorange_stack():
+def test_area_to_line_autorange():
     axis = ds.core.LinearAxis()
     lincoords_y = axis.compute_index(
         axis.compute_scale_and_translate((-4., 4.), 7), 7)
@@ -587,7 +587,7 @@ def test_area_to_zero_autorange_stack():
 
     # When a line is specified to fill to, this line is not included in
     # the fill.  So we expect the y=0 line to not be filled.
-    agg = cvs.area(ddf, 'x', ['y0', 'y1'], ds.count())
+    agg = cvs.area(ddf, 'x', 'y0', ds.count(), y_stack='y1')
 
     sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -507,7 +507,38 @@ def test_auto_range_line():
     assert_eq(agg, out)
 
 
-def test_area_to_zero_fixedrange():
+@pytest.mark.parametrize('df,x,y,ax', [
+    # axis1 none constant
+    (pd.DataFrame({
+        'x0': [-4, np.nan],
+        'x1': [-2, 2],
+        'x2': [0, 4],
+        'y0': [0, np.nan],
+        'y1': [-4, 4],
+        'y2': [0, 0]
+    }, dtype='float32'), ['x0', 'x1', 'x2'], ['y0', 'y1', 'y2'], 1),
+
+    # axis0 single
+    (pd.DataFrame({
+        'x': [-4, -2, 0, np.nan, 2, 4],
+        'y': [0, -4, 0, np.nan, 4, 0],
+    }), 'x', 'y', 0),
+
+    # axis0 multi
+    (pd.DataFrame({
+        'x0': [-4, -2, 0],
+        'x1': [np.nan, 2, 4],
+        'y0': [0, -4, 0],
+        'y1': [np.nan, 4, 0],
+    }, dtype='float32'), ['x0', 'x1'], ['y0', 'y1'], 0),
+
+    # axis1 ragged arrays
+    (pd.DataFrame({
+        'x': pd.array([[-4, -2, 0], [2, 4]], dtype='Ragged[float32]'),
+        'y': pd.array([[0, -4, 0], [4, 0]], dtype='Ragged[float32]')
+    }), 'x', 'y', 1)
+])
+def test_area_to_zero_fixedrange(df, x, y, ax):
     axis = ds.core.LinearAxis()
     lincoords_y = axis.compute_index(
         axis.compute_scale_and_translate((-2.25, 2.25), 5), 5)
@@ -518,13 +549,9 @@ def test_area_to_zero_fixedrange():
     cvs = ds.Canvas(plot_width=9, plot_height=5,
                     x_range=[-3.75, 3.75], y_range=[-2.25, 2.25])
 
-    df = pd.DataFrame({
-        'x': [-4, -2, 0, np.nan, 2, 4],
-        'y': [0, -4, 0, np.nan, 4, 0],
-    })
     ddf = dd.from_pandas(df, npartitions=2)
 
-    agg = cvs.area(ddf, 'x', 'y', ds.count())
+    agg = cvs.area(ddf, x, y, ds.count(), axis=ax)
 
     sol = np.array([[0, 1, 1, 0, 0, 0, 0, 0, 0],
                     [1, 1, 1, 1, 0, 0, 0, 0, 0],
@@ -538,7 +565,110 @@ def test_area_to_zero_fixedrange():
     assert_eq(agg, out)
 
 
-def test_area_to_zero_autorange():
+@pytest.mark.parametrize('df,x,y,ax', [
+    # axis1 none constant
+    (pd.DataFrame({
+        'x0': [-4, 0],
+        'x1': [-2, 2],
+        'x2': [0, 4],
+        'y0': [0, 0],
+        'y1': [-4, -4],
+        'y2': [0, 0]
+    }, dtype='float32'), ['x0', 'x1', 'x2'], ['y0', 'y1', 'y2'], 1),
+
+    # axis1 y constant
+    (pd.DataFrame({
+        'x0': [-4, 0],
+        'x1': [-2, 2],
+        'x2': [0, 4],
+    }, dtype='float32'),
+     ['x0', 'x1', 'x2'], np.array([0, -4, 0], dtype='float32'), 1),
+
+    # axis0 single
+    (pd.DataFrame({
+        'x': [-4, -2, 0, 0, 2, 4],
+        'y': [0, -4, 0, 0, -4, 0],
+    }), 'x', 'y', 0),
+
+    # axis0 multi
+    (pd.DataFrame({
+        'x0': [-4, -2, 0],
+        'x1': [0, 2, 4],
+        'y0': [0, -4, 0],
+        'y1': [0, -4, 0],
+    }, dtype='float32'), ['x0', 'x1'], ['y0', 'y1'], 0),
+
+    # axis0 multi, y string
+    (pd.DataFrame({
+        'x0': [-4, -2, 0],
+        'x1': [0, 2, 4],
+        'y0': [0, -4, 0],
+    }, dtype='float32'), ['x0', 'x1'], 'y0', 0),
+
+    # axis1 ragged arrays
+    (pd.DataFrame({
+        'x': pd.array([[-4, -2, 0], [0, 2, 4]], dtype='Ragged[float32]'),
+        'y': pd.array([[0, -4, 0], [0, -4, 0]], dtype='Ragged[float32]')
+    }), 'x', 'y', 1)
+])
+def test_area_to_zero_autorange(df, x, y, ax):
+    axis = ds.core.LinearAxis()
+    lincoords_y = axis.compute_index(
+        axis.compute_scale_and_translate((-4., 0.), 7), 7)
+    lincoords_x = axis.compute_index(
+        axis.compute_scale_and_translate((-4., 4.), 13), 13)
+
+    cvs = ds.Canvas(plot_width=13, plot_height=7)
+
+    ddf = dd.from_pandas(df, npartitions=2)
+    agg = cvs.area(ddf, x, y, ds.count(), axis=ax)
+
+    sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0],
+                    [0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0],
+                    [0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0],
+                    [0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0],
+                    [1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1]],
+                   dtype='i4')
+
+    out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
+                       dims=['y', 'x'])
+    assert_eq(agg, out)
+
+
+@pytest.mark.parametrize('df,x,y,ax', [
+    # axis1 none constant
+    (pd.DataFrame({
+        'x0': [-4, np.nan],
+        'x1': [-2, 2],
+        'x2': [0, 4],
+        'y0': [0, np.nan],
+        'y1': [-4, 4],
+        'y2': [0, 0]
+    }, dtype='float32'), ['x0', 'x1', 'x2'], ['y0', 'y1', 'y2'], 1),
+
+    # axis0 single
+    (pd.DataFrame({
+        'x': [-4, -2, 0, np.nan, 2, 4],
+        'y': [0, -4, 0, np.nan, 4, 0],
+    }), 'x', 'y', 0),
+
+    # axis0 multi
+    (pd.DataFrame({
+        'x0': [-4, -2, 0],
+        'x1': [np.nan, 2, 4],
+        'y0': [0, -4, 0],
+        'y1': [np.nan, 4, 0],
+    }, dtype='float32'), ['x0', 'x1'], ['y0', 'y1'], 0),
+
+    # axis1 ragged arrays
+    (pd.DataFrame({
+        'x': pd.array([[-4, -2, 0], [2, 4]], dtype='Ragged[float32]'),
+        'y': pd.array([[0, -4, 0], [4, 0]], dtype='Ragged[float32]')
+    }), 'x', 'y', 1)
+])
+def test_area_to_zero_autorange_gap(df, x, y, ax):
     axis = ds.core.LinearAxis()
     lincoords_y = axis.compute_index(
         axis.compute_scale_and_translate((-4., 4.), 7), 7)
@@ -547,13 +677,9 @@ def test_area_to_zero_autorange():
 
     cvs = ds.Canvas(plot_width=13, plot_height=7)
 
-    df = pd.DataFrame({
-        'x': [-4, -2, 0, np.nan, 2, 4],
-        'y': [0, -4, 0, np.nan, 4, 0],
-    })
     ddf = dd.from_pandas(df, npartitions=2)
 
-    agg = cvs.area(ddf, 'x', 'y', ds.count())
+    agg = cvs.area(ddf, x, y, ds.count(), axis=ax)
 
     sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -569,7 +695,129 @@ def test_area_to_zero_autorange():
     assert_eq(agg, out)
 
 
-def test_area_to_line_autorange():
+@pytest.mark.parametrize('df,x,y,y_stack,ax', [
+    # axis1 none constant
+    (pd.DataFrame({
+        'x0': [-4, 0],
+        'x1': [-2, 2],
+        'x2': [0, 4],
+        'y0': [0, 0],
+        'y1': [-4, -4],
+        'y2': [0, 0],
+        'y3': [0, 0],
+        'y4': [-2, -2],
+        'y5': [0, 0],
+    }, dtype='float32'),
+     ['x0', 'x1', 'x2'], ['y0', 'y1', 'y2'], ['y3', 'y4', 'y5'], 1),
+
+    # axis1 y constant
+    (pd.DataFrame({
+        'x0': [-4, 0],
+        'x1': [-2, 2],
+        'x2': [0, 4],
+    }, dtype='float32'),
+     ['x0', 'x1', 'x2'],
+     np.array([0, -4, 0]),
+     np.array([0, -2, 0], dtype='float32'), 1),
+
+    # axis0 single
+    (pd.DataFrame({
+        'x': [-4, -2, 0, 0, 2, 4],
+        'y': [0, -4, 0, 0, -4, 0],
+        'y_stack': [0, -2, 0, 0, -2, 0],
+    }), 'x', 'y', 'y_stack', 0),
+
+    # axis0 multi
+    (pd.DataFrame({
+        'x0': [-4, -2, 0],
+        'x1': [0, 2, 4],
+        'y0': [0, -4, 0],
+        'y1': [0, -4, 0],
+        'y2': [0, -2, 0],
+        'y3': [0, -2, 0],
+    }, dtype='float32'), ['x0', 'x1'], ['y0', 'y1'], ['y2', 'y3'], 0),
+
+    # axis0 multi, y string
+    (pd.DataFrame({
+        'x0': [-4, -2, 0],
+        'x1': [0, 2, 4],
+        'y0': [0, -4, 0],
+        'y2': [0, -2, 0],
+    }, dtype='float32'), ['x0', 'x1'], 'y0', 'y2', 0),
+
+    # axis1 ragged arrays
+    (pd.DataFrame({
+        'x': pd.array([[-4, -2, 0], [0, 2, 4]], dtype='Ragged[float32]'),
+        'y': pd.array([[0, -4, 0], [0, -4, 0]], dtype='Ragged[float32]'),
+        'y_stack': pd.array([[0, -2, 0], [0, -2, 0]], dtype='Ragged[float32]')
+    }), 'x', 'y', 'y_stack', 1)
+])
+def test_area_to_line_autorange(df, x, y, y_stack, ax):
+    axis = ds.core.LinearAxis()
+    lincoords_y = axis.compute_index(
+        axis.compute_scale_and_translate((-4., 0.), 7), 7)
+    lincoords_x = axis.compute_index(
+        axis.compute_scale_and_translate((-4., 4.), 13), 13)
+
+    cvs = ds.Canvas(plot_width=13, plot_height=7)
+
+    ddf = dd.from_pandas(df, npartitions=2)
+    agg = cvs.area(ddf, x, y, ds.count(), axis=ax, y_stack=y_stack)
+
+    sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+                    [0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0],
+                    [0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0],
+                    [0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
+                   dtype='i4')
+
+    out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
+                       dims=['y', 'x'])
+    assert_eq(agg, out)
+
+
+@pytest.mark.parametrize('df,x,y,y_stack,ax', [
+    # axis1 none constant
+    (pd.DataFrame({
+        'x0': [-4, np.nan],
+        'x1': [-2, 2],
+        'x2': [0, 4],
+        'y0': [0, np.nan],
+        'y1': [-4, 4],
+        'y2': [0, 0],
+        'y4': [0, 0],
+        'y5': [0, 0],
+        'y6': [0, 0]
+    }, dtype='float32'),
+     ['x0', 'x1', 'x2'], ['y0', 'y1', 'y2'], ['y4', 'y5', 'y6'], 1),
+
+    # axis0 single
+    (pd.DataFrame({
+        'x': [-4, -2, 0, np.nan, 2, 4],
+        'y': [0, -4, 0, np.nan, 4, 0],
+        'y_stack': [0, 0, 0, 0, 0, 0],
+    }), 'x', 'y', 'y_stack', 0),
+
+    # axis0 multi
+    (pd.DataFrame({
+        'x0': [-4, -2, 0],
+        'x1': [np.nan, 2, 4],
+        'y0': [0, -4, 0],
+        'y1': [np.nan, 4, 0],
+        'y2': [0, 0, 0],
+        'y3': [0, 0, 0],
+    }, dtype='float32'), ['x0', 'x1'], ['y0', 'y1'], ['y2', 'y3'], 0),
+
+    # axis1 ragged arrays
+    (pd.DataFrame({
+        'x': pd.array([[-4, -2, 0], [2, 4]], dtype='Ragged[float32]'),
+        'y': pd.array([[0, -4, 0], [4, 0]], dtype='Ragged[float32]'),
+        'y_stack': pd.array([[0, 0, 0], [0, 0]], dtype='Ragged[float32]')
+    }), 'x', 'y', 'y_stack', 1)
+])
+def test_area_to_line_autorange_gap(df, x, y, y_stack, ax):
     axis = ds.core.LinearAxis()
     lincoords_y = axis.compute_index(
         axis.compute_scale_and_translate((-4., 4.), 7), 7)
@@ -578,16 +826,11 @@ def test_area_to_line_autorange():
 
     cvs = ds.Canvas(plot_width=13, plot_height=7)
 
-    df = pd.DataFrame({
-        'x': [-4, -2, 0, np.nan, 2, 4],
-        'y0': [0, -4, 0, np.nan, 4, 0],
-        'y1': [0,  0, 0, np.nan, 0, 0],
-    })
     ddf = dd.from_pandas(df, npartitions=2)
 
     # When a line is specified to fill to, this line is not included in
     # the fill.  So we expect the y=0 line to not be filled.
-    agg = cvs.area(ddf, 'x', 'y0', ds.count(), y_stack='y1')
+    agg = cvs.area(ddf, x, y, ds.count(), y_stack=y_stack, axis=ax)
 
     sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -599,7 +842,7 @@ def test_area_to_line_autorange():
                    dtype='i4')
 
     out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
-                       dims=['y0', 'x'])
+                       dims=['y', 'x'])
     assert_eq(agg, out)
 
 

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -794,14 +794,14 @@ def test_line_awkward_point_on_upper_bound_maps_to_last_pixel():
     num_y_pixels = 2
     ymax = 0.1
     bigy = 10e9
-    
+
     sy = num_y_pixels/ymax
     y = bigy-(bigy-ymax) # simulates clipped line
 
     # check that test is set up ok
     assert y!=ymax
     np.testing.assert_almost_equal(y,ymax,decimal=6)
-    
+
     _,pymax = map_onto_pixel_for_line((1.0, 0.0, sy, 0.0),
                                       (0.0, 1.0, 0.0, ymax),
                                       1.0, y)

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -915,7 +915,7 @@ def test_area_to_zero_autorange():
     assert_eq(agg, out)
 
 
-def test_area_to_zero_autorange_stack():
+def test_area_to_line_autorange():
     axis = ds.core.LinearAxis()
     lincoords_y = axis.compute_index(
         axis.compute_scale_and_translate((-4., 4.), 7), 7)
@@ -932,7 +932,7 @@ def test_area_to_zero_autorange_stack():
 
     # When a line is specified to fill to, this line is not included in
     # the fill.  So we expect the y=0 line to not be filled.
-    agg = cvs.area(df, 'x', ['y0', 'y1'], ds.count())
+    agg = cvs.area(df, 'x', 'y0', ds.count(), y_stack='y1')
 
     sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -853,3 +853,96 @@ def test_line_autorange_axis1_ragged():
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
     assert_eq(agg, out)
+
+
+def test_area_to_zero_fixedrange():
+    axis = ds.core.LinearAxis()
+    lincoords_y = axis.compute_index(
+        axis.compute_scale_and_translate((-2.25, 2.25), 5), 5)
+
+    lincoords_x = axis.compute_index(
+        axis.compute_scale_and_translate((-3.75, 3.75), 9), 9)
+
+    cvs = ds.Canvas(plot_width=9, plot_height=5,
+                    x_range=[-3.75, 3.75], y_range=[-2.25, 2.25])
+
+    df = pd.DataFrame({
+        'x': [-4, -2, 0, np.nan, 2, 4],
+        'y': [0, -4, 0, np.nan, 4, 0],
+    })
+
+    agg = cvs.area(df, 'x', 'y', ds.count())
+
+    sol = np.array([[0, 1, 1, 0, 0, 0, 0, 0, 0],
+                    [1, 1, 1, 1, 0, 0, 0, 0, 0],
+                    [1, 1, 1, 1, 1, 0, 1, 1, 1],
+                    [0, 0, 0, 0, 0, 0, 1, 1, 1],
+                    [0, 0, 0, 0, 0, 0, 1, 1, 0]],
+                   dtype='i4')
+
+    out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
+                       dims=['y', 'x'])
+    assert_eq(agg, out)
+
+
+def test_area_to_zero_autorange():
+    axis = ds.core.LinearAxis()
+    lincoords_y = axis.compute_index(
+        axis.compute_scale_and_translate((-4., 4.), 7), 7)
+    lincoords_x = axis.compute_index(
+        axis.compute_scale_and_translate((-4., 4.), 13), 13)
+
+    cvs = ds.Canvas(plot_width=13, plot_height=7)
+
+    df = pd.DataFrame({
+        'x': [-4, -2, 0, np.nan, 2, 4],
+        'y': [0, -4, 0, np.nan, 4, 0],
+    })
+
+    agg = cvs.area(df, 'x', 'y', ds.count())
+
+    sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+                    [1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]],
+                   dtype='i4')
+
+    out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
+                       dims=['y', 'x'])
+    assert_eq(agg, out)
+
+
+def test_area_to_zero_autorange_stack():
+    axis = ds.core.LinearAxis()
+    lincoords_y = axis.compute_index(
+        axis.compute_scale_and_translate((-4., 4.), 7), 7)
+    lincoords_x = axis.compute_index(
+        axis.compute_scale_and_translate((-4., 4.), 13), 13)
+
+    cvs = ds.Canvas(plot_width=13, plot_height=7)
+
+    df = pd.DataFrame({
+        'x': [-4, -2, 0, np.nan, 2, 4],
+        'y0': [0, -4, 0, np.nan, 4, 0],
+        'y1': [0,  0, 0, np.nan, 0, 0],
+    })
+
+    # When a line is specified to fill to, this line is not included in
+    # the fill.  So we expect the y=0 line to not be filled.
+    agg = cvs.area(df, 'x', ['y0', 'y1'], ds.count())
+
+    sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0]],
+                   dtype='i4')
+
+    out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
+                       dims=['y0', 'x'])
+    assert_eq(agg, out)

--- a/examples/user_guide/3_Timeseries.ipynb
+++ b/examples/user_guide/3_Timeseries.ipynb
@@ -251,6 +251,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Area plots\n",
+    "As an alternative to plotting time-series data as a line, the same data can be plotted as a filled area plot.  This approach serves to emphasise whether the time series has a positive or negative sign.  Here is an example of a filled area plot for the 'a' curve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cvs = ds.Canvas(x_range=x_range, y_range=y_range, plot_height=300, plot_width=900)\n",
+    "agg = cvs.area(df, 'Time', 'a')\n",
+    "img = tf.shade(agg)\n",
+    "img"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By specifying two column labels for the y argument, an area plot can also be used to display the difference between two curves.  Here is an example of an area plot of the difference between the 'a' and 'b' curves"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cvs = ds.Canvas(x_range=x_range, y_range=y_range, plot_height=300, plot_width=900)\n",
+    "agg = cvs.area(df, 'Time', ['a', 'b'])\n",
+    "img = tf.shade(agg)\n",
+    "img"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Dynamic Plots\n",
     "\n",
     "In practice, it might be difficult to cycle through each of the curves to find one that's different, as done above.  Perhaps a criterion based on similarity could be devised, choosing the curve most dissimilar from the rest to plot in this way, which would be an interesting topic for future research.  In any case, one thing that can always be done is to make the plot fully interactive, so that the viewer can zoom in and discover such patterns dynamically.\n",

--- a/examples/user_guide/3_Timeseries.ipynb
+++ b/examples/user_guide/3_Timeseries.ipynb
@@ -262,7 +262,7 @@
    "outputs": [],
    "source": [
     "cvs = ds.Canvas(x_range=x_range, y_range=y_range, plot_height=300, plot_width=900)\n",
-    "agg = cvs.area(df, 'Time', 'a')\n",
+    "agg = cvs.area(df, x='Time', y='a')\n",
     "img = tf.shade(agg)\n",
     "img"
    ]
@@ -271,7 +271,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By specifying two column labels for the y argument, an area plot can also be used to display the difference between two curves.  Here is an example of an area plot of the difference between the 'a' and 'b' curves"
+    "By specifying the y_stack argument, an area plot can also be used to display the difference between two curves.  Here is an example of an area plot of the difference between the 'a' and 'b' curves"
    ]
   },
   {
@@ -281,7 +281,7 @@
    "outputs": [],
    "source": [
     "cvs = ds.Canvas(x_range=x_range, y_range=y_range, plot_height=300, plot_width=900)\n",
-    "agg = cvs.area(df, 'Time', ['a', 'b'])\n",
+    "agg = cvs.area(df, x='Time', y='a', y_stack='b')\n",
     "img = tf.shade(agg)\n",
     "img"
    ]


### PR DESCRIPTION
## Overview
This PR add a new `Canvas.area` function to support the creation of filled area plots with Datashader.

## Examples
Imports and dataset
```python
import pandas as pd  # doctest: +SKIP
import numpy as np
import datashader as ds
from datashader import Canvas
import datashader.transfer_functions as tf
cvs = Canvas()
df = pd.DataFrame({
       'A1': [1, 1.5, 2, 2.5, 3, 4],
       'A2': [1.6, 2.1, 2.9, 3.2, 4.2, 5],
       'B1': [10, 12, 11, 14, 13, 15],
       'B2': [5, 9, 10, 7, 8, 12],
    }, dtype='float64')
df
```

Plot 'A1' vs 'B1' and 'B2' as lines
```python
agg = cvs.line(df, x='A1', y=['B1', 'B2'], axis=0)
tf.spread(tf.shade(agg))
```
![index1](https://user-images.githubusercontent.com/15064365/57113751-fc86a700-6d13-11e9-8563-9f1f0e06f771.png)

Plot filled area from 'B1' to y=0.
```python
agg = cvs.area(df, x='A1', y='B1')
tf.shade(agg)
```
![index2](https://user-images.githubusercontent.com/15064365/57113757-03adb500-6d14-11e9-98de-42335cc3bc0a.png)

Plot filled area from 'B1' to 'B2' using the `y_stack` argument to `Canvas.area`.
```python
agg = cvs.area(df, x='A1', y='B1', y_stack='B2')
tf.shade(agg)
```
![index3](https://user-images.githubusercontent.com/15064365/57113764-0a3c2c80-6d14-11e9-8c43-46e2fdd06287.png)

Mutli-line with axis=0
```python
agg = cvs.line(df, x=['A1', 'A2'], y=['B1', 'B2'], axis=0, agg=ds.count())  # doctest: +SKIP
tf.spread(tf.shade(agg))
```

![index8](https://user-images.githubusercontent.com/15064365/57113833-5edfa780-6d14-11e9-9eee-2bda597b6c54.png)

Multi-area with axis=0
```
agg = cvs.area(df, x=['A1', 'A2'], y=['B1', 'B2'], axis=0, agg=ds.count())  # doctest: +SKIP
tf.shade(agg)
```
![index4](https://user-images.githubusercontent.com/15064365/57113851-7454d180-6d14-11e9-89c1-b154b0ee3854.png)

Mutli-line with axis=0 and shared x
```python
agg = cvs.line(df, x='A1', y=['B1', 'B2'], axis=0)
tf.spread(tf.shade(agg))
```
![index9](https://user-images.githubusercontent.com/15064365/57113897-bd0c8a80-6d14-11e9-9074-ca85728a9833.png)

Multi-area with axis=0 and shared x
```python
agg = cvs.area(df, x='A1', y=['B1', 'B2'], agg=ds.count(), axis=0)  # doctest: +SKIP
tf.shade(agg)
```
![index5](https://user-images.githubusercontent.com/15064365/57113915-d0b7f100-6d14-11e9-9b8a-67d0e7d77527.png)

Multi-line with axis=1
```python
agg = cvs.line(df, x=['A1', 'A2'], y=['B1', 'B2'], axis=1)
tf.spread(tf.shade(agg))
```
![index10](https://user-images.githubusercontent.com/15064365/57113964-05c44380-6d15-11e9-8e26-d42b9a830aa9.png)

Multi-area with axis=1
```python
agg = cvs.area(df, x=['A1', 'A2'], y=['B1', 'B2'], agg=ds.count(), axis=1)
tf.shade(agg)
```
![index6](https://user-images.githubusercontent.com/15064365/57113993-196faa00-6d15-11e9-9c8f-84ea69dac375.png)

Ragged array lines
```
df_ragged = pd.DataFrame({  # doctest: +SKIP
           'A1': pd.array([
               [1, 1.5], [2, 2.5, 3], [1.6, 2, 3, 4], [3.2, 4, 5]],
               dtype='Ragged[float32]'),
           'B1': pd.array([
               [10, 12], [11, 14, 13], [10, 7, 9, 10], [7, 8, 12]],
               dtype='Ragged[float32]'),
           'B2': pd.array([
               [6, 10], [9, 10, 10], [9, 5, 8, 9], [4, 5, 11]],
               dtype='Ragged[float32]'),
           'group': pd.Categorical([0, 1, 2, 1])
        })
        
agg = cvs.line(df_ragged, x='A1', y='B1', axis=1)
tf.spread(tf.shade(agg))
```
![index11](https://user-images.githubusercontent.com/15064365/57114029-4623c180-6d15-11e9-93b9-984bb9872930.png)

Ragged areas filled to zero line
```python
agg = cvs.area(df_ragged, x='A1', y='B1', agg=ds.count(), axis=1)
tf.shade(agg)
```
Ragged areas filled to ragged line
```python
agg = cvs.area(df_ragged, x='A1', y='B1', y_stack='B2', agg=ds.count(), axis=1)
tf.shade(agg)
```
![index12](https://user-images.githubusercontent.com/15064365/57114094-a0bd1d80-6d15-11e9-931f-2ad34266822a.png)

Ragged areas filled to ragged with `count_cat` aggregator
```
agg = cvs.area(df_ragged, x='A1', y='B1', y_stack='B2',
               agg=ds.count_cat('group'), axis=1)
tf.shade(agg)
```
![index13](https://user-images.githubusercontent.com/15064365/57114147-e0840500-6d15-11e9-8d82-71395bf6327f.png)

## Documentation
I added a new area plot section to the Timeseries user guide. See the user guide for full code:
```python
cvs = ds.Canvas(plot_height=300, plot_width=900)
agg = cvs.area(df, 'Time', 'a')
img = tf.shade(agg)
img
```
![index](https://user-images.githubusercontent.com/15064365/55672358-15f91800-5868-11e9-9dbf-0cb7a6fdc8b8.png)

## Performance
I haven't done extensive benchmarking, but in all of the cases I've tried the render time has been within a factor of two of the time to render the line by itself.

