### PR TITLE
Adding importorskip for fastparquet

### DIFF
--- a/datashader/tests/test_spatial.py
+++ b/datashader/tests/test_spatial.py
@@ -7,6 +7,8 @@ import dask.dataframe as dd
 from datashader import Canvas
 import datashader.spatial.points as dsp
 
+pytest.importorskip('fastparquet')
+
 
 @pytest.fixture()
 def df():


### PR DESCRIPTION
This will fix the types of errors that we are getting in https://github.com/conda-forge/datashader-feedstock/pull/10 where fastparquet isn't in the test environment