### PR TITLE
Tornado pinning for tests

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Datashader Roadmap, as of 4/2018
 
-Datashader is an open-source project, with contributions from a variety of developers with different priorities, so it is not possible to lay out a fully detailed timeline of upcoming features.  That said, there are clear priorities that the current developers have agreed on, which will be described here and updated occasionally. 
+Datashader is an open-source project, with contributions from a variety of developers with different priorities, so it is not possible to lay out a fully detailed timeline of upcoming features.  That said, there are clear priorities that the current developers have agreed on, which will be described here and updated occasionally.
 
-If you need any of the functionality listed below and want to help make it a priority, please respond to the relevant issue listed (preferably with offers of coding, financial, or other assistance!). 
+If you need any of the functionality listed below and want to help make it a priority, please respond to the relevant issue listed (preferably with offers of coding, financial, or other assistance!).
 
 1. **Ongoing maintenance, improved documentation and examples**
   - As always, there are various bugs and usability issues reported on the issue tracker, and we will address these as time permits.


### PR DESCRIPTION
PR trying to fix the tests in https://github.com/pyviz/datashader/pull/734:

Related issues: 
https://github.com/pyviz/holoviews/pull/3560 
https://github.com/jupyter/nbconvert/issues/894
 
The real fix is an nbconvert release but we can't count on that happening soon. My first commit is just to check that nbsmoke is consistently failing - after that I'll pin tornado to get the tests passing again.