### PR TITLE
added tile_previewer utility function

### DIFF
--- a/datashader/tiles.py
+++ b/datashader/tiles.py
@@ -316,6 +316,62 @@ class TileRenderer(object):
             yield (img, x, y, z)
 
 
+def tile_previewer(full_extent, tileset_url,
+                   output_dir=None,
+                   filename='index.html',
+                   title='Datashader Tileset',
+                   min_zoom=0, max_zoom=40,
+                   height=None, width=None,
+                   **kwargs):
+    '''Helper function for creating a simple Bokeh figure with
+    a WMTS Tile Source.
+
+    Notes
+    -----
+    - if you don't supply height / width, stretch_both sizing_mode is used.
+    - supply an output_dir to write figure to disk.
+    '''
+
+    try:
+        from bokeh.plotting import figure
+        from bokeh.models.tiles import WMTSTileSource
+        from bokeh.io import output_file, save
+        from os import path
+    except ImportError:
+        raise ImportError('conda install bokeh to enable creation of simple tile viewer')
+
+    if output_dir:
+        output_file(filename=path.join(output_dir, filename),
+                    title=title)
+
+    xmin, ymin, xmax, ymax = full_extent
+
+    if height and width:
+        p = figure(width=width, height=height,
+                   x_range=(xmin, xmax),
+                   y_range=(ymin, ymax),
+                   tools="pan,wheel_zoom,reset", **kwargs)
+    else:
+        p = figure(sizing_mode='stretch_both',
+                   x_range=(xmin, xmax),
+                   y_range=(ymin, ymax),
+                   tools="pan,wheel_zoom,reset", **kwargs)
+
+    p.background_fill_color = 'black'
+    p.grid.grid_line_alpha = 0
+    p.axis.visible = True
+
+    tile_source = WMTSTileSource(url=tileset_url,
+                                 min_zoom=min_zoom,
+                                 max_zoom=max_zoom)
+    p.add_tile(tile_source, render_parents=False)
+
+    if output_dir:
+        save(p)
+
+    return p
+
+
 class FileSystemTileRenderer(TileRenderer):
 
     def render(self, da, level):


### PR DESCRIPTION
The `tile_previewer` utility is a helper for creating a Bokeh figure with a tile layer. It works in notebooks, but can also save the figure out to be stored with a tileset.  A future PR should include generating an `index.html` file in the root of the tileset directory so tiles can be easily looked at.

Example Usage
---------------

```python
from datashader.tiles import tile_previewer
tileset_url = 'https://my-s3-bucket.s3.amazonaws.com/9615-forced-test/{Z}/{X}/{Y}.png'
fig = tile_previewer(full_extent=full_extent_of_data, height=800, width=800, tileset_url=tileset_url)
```