### PR TITLE
Implemented distributed regridding

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -675,7 +675,7 @@ The axis argument to Canvas.line must be 0 or 1
         Also supports resampling out-of-core DataArrays backed by dask
         Arrays. By default it will try to maintain the same chunksize
         in the output array but a custom chunksize may be provided.
-        If there are memory constrains they may be defined using the
+        If there are memory constraints they may be defined using the
         max_mem parameter, which determines how large the chunks in
         memory may be.
 
@@ -696,7 +696,7 @@ The axis argument to Canvas.line must be 0 or 1
         agg : Reduction, optional default=mean()
             Resampling mode when downsampling raster.
             options include: first, last, mean, mode, var, std, min, max
-            Also accepts string names, for backwards compatibility.
+            Accepts an executable function, function object, or string name.
         interpolate : str, optional  default=linear
             Resampling mode when upsampling raster.
             options include: nearest, linear.

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -878,7 +878,7 @@ The axis argument to Canvas.line must be 0 or 1
         coords = {xdim: xs, ydim: ys}
         dims = [ydim, xdim]
         attrs = dict(res=res[0])
-        if source._file_obj is not None:
+        if source._file_obj is not None and hasattr(source._file_obj, 'nodata'):
             attrs['nodata'] = source._file_obj.nodata
 
         # Handle DataArray with layers

--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -158,7 +158,7 @@ def compute_chunksize(src, w, h, chunksize=None, max_mem=None):
     h : int
         New grid height
     chunksize : tuple(int, int) (optional)
-        Size of the output chunks. By default this the chunk size is
+        Size of the output chunks. By default the chunk size is
         inherited from the *src* array.
     max_mem : int (optional)
         The maximum number of bytes that should be loaded into memory
@@ -192,7 +192,7 @@ def compute_chunksize(src, w, h, chunksize=None, max_mem=None):
             "could not find a chunksize that avoids loading too much "
             "data into memory. Either relax the memory constraint to "
             "a minimum of %d bytes or resample to a larger grid size. "
-            "Note: A future implementation may handle this condition "
+            "Note: A future implementation could handle this condition "
             "by declaring temporary arrays." % min_mem)
     return ch, cw
 
@@ -222,7 +222,7 @@ def resample_2d_distributed(src, w, h, ds_method='mean', us_method='linear',
         If None, numpy's default value is used.
     mode_rank : scalar (optional)
         The rank of the frequency determined by the *ds_method*
-        ``DS_MODE``. One (the default) means most frequent value, zwo
+        ``DS_MODE``. One (the default) means most frequent value, two
         means second most frequent value, and so forth.
     chunksize : tuple(int, int) (optional)
         Size of the output chunks. By default this the chunk size is
@@ -397,7 +397,7 @@ def downsample_2d(src, w, h, method=DS_MEAN, fill_value=None, mode_rank=1, out=N
         otherwise numpy's default value is used.
     mode_rank : scalar (optional)
         The rank of the frequency determined by the *ds_method*
-        ``DS_MODE``. One (the default) means most frequent value, zwo
+        ``DS_MODE``. One (the default) means most frequent value, two
         means second most frequent value, and so forth.
     out : numpy.ndarray (optional)
         Alternate output array in which to place the result. The

--- a/datashader/tests/test_raster.py
+++ b/datashader/tests/test_raster.py
@@ -385,20 +385,22 @@ def test_raster_distributed_downsample(in_size, out_size, agg):
     assert np.allclose(agg_arr.x.values, agg_darr.x.values)
     assert np.allclose(agg_arr.y.values, agg_darr.y.values)
 
-def test_raster_distributed_upsample():
+
+@pytest.mark.parametrize('in_size, out_size', product(range(2, 5), range(7, 9)))
+def test_raster_distributed_upsample(in_size, out_size):
     """
     Ensure that distributed regrid is equivalent to regular regrid.
     """
-    cvs = ds.Canvas(plot_height=8, plot_width=8)
+    cvs = ds.Canvas(plot_height=out_size, plot_width=out_size)
 
-    size = 4
-    vs = np.linspace(-1, 1, size)
+    vs = np.linspace(-1, 1, in_size)
     xs, ys = np.meshgrid(vs, vs)
     arr = np.sin(xs*ys)
 
     darr = da.from_array(arr, (2, 2))
-    xr_darr = xr.DataArray(darr, coords=[('y', range(size)), ('x', range(size))], name='z')
-    xr_arr = xr.DataArray(arr, coords=[('y', range(size)), ('x', range(size))], name='z')
+    coords = [('y', range(in_size)), ('x', range(in_size))]
+    xr_darr = xr.DataArray(darr, coords=coords, name='z')
+    xr_arr = xr.DataArray(arr, coords=coords, name='z')
 
     agg_arr = cvs.raster(xr_arr, interpolate='nearest')
     agg_darr = cvs.raster(xr_darr, interpolate='nearest')

--- a/datashader/tests/test_raster.py
+++ b/datashader/tests/test_raster.py
@@ -2,6 +2,7 @@ import pytest
 rasterio = pytest.importorskip("rasterio")
 
 from os import path
+from itertools import product
 
 import datashader as ds
 import xarray as xr
@@ -361,28 +362,28 @@ def test_raster_single_pixel_range_with_padding():
     assert np.allclose(agg.y.values, np.array([-0.40625, -0.21875, -0.03125,  0.15625]))
 
 
-def test_raster_distributed_downsample():
+@pytest.mark.parametrize('in_size, out_size, agg', product(range(5, 8), range(2, 5), ['mean', 'min', 'max', 'first', 'last', 'var', 'std', 'mode']))
+def test_raster_distributed_downsample(in_size, out_size, agg):
     """
     Ensure that distributed regrid is equivalent to regular regrid.
     """
-    cvs = ds.Canvas(plot_height=2, plot_width=2)
+    cvs = ds.Canvas(plot_height=out_size, plot_width=out_size)
 
-    size = 4
-    vs = np.linspace(-1, 1, size)
+    vs = np.linspace(-1, 1, in_size)
     xs, ys = np.meshgrid(vs, vs)
     arr = np.sin(xs*ys)
 
     darr = da.from_array(arr, (2, 2))
-    xr_darr = xr.DataArray(darr, coords=[('y', range(size)), ('x', range(size))], name='z')
-    xr_arr = xr.DataArray(arr, coords=[('y', range(size)), ('x', range(size))], name='z')
+    coords = [('y', range(in_size)), ('x', range(in_size))]
+    xr_darr = xr.DataArray(darr, coords=coords, name='z')
+    xr_arr = xr.DataArray(arr, coords=coords, name='z')
 
-    agg_arr = cvs.raster(xr_arr)
-    agg_darr = cvs.raster(xr_darr)
+    agg_arr = cvs.raster(xr_arr, agg=agg)
+    agg_darr = cvs.raster(xr_darr, agg=agg)
 
     assert np.allclose(agg_arr.data, agg_darr.data.compute())
     assert np.allclose(agg_arr.x.values, agg_darr.x.values)
     assert np.allclose(agg_arr.y.values, agg_darr.y.values)
-
 
 def test_raster_distributed_upsample():
     """


### PR DESCRIPTION
Implements regridding of ``dask.array.Array`` backed ``xarray.DataArray`` objects without loading the entire array into memory.

The basic idea here is that the operation will no longer load dask arrays into memory, instead it will resample the original data in chunks and then stack the resampled chunks along the two axes. By default it will try to keep the chunksize consistent, however it now also exposes a memory constraint which can be used to limit the amount of data in memory at any one time. 

If enabled it is possible to end up with situations where resampling cannot be performed given the memory constraints, e.g. let us say you have a 1 GB array which is roughly 12k x 12k in shape, and we want to resample it into a 10x10 grid. If we we give it a memory limit of 100 KB, even if each output chunk is only 1x1 it still has to load a 1200x1200 grid, i.e. about 11.5 MB, into memory . This could be solved by splitting the task and creating temporary chunks which are then aggregated but I considered that out of scope. Instead you will get an error that you have to relax the memory constraint.

Here is the profiling output when regridding a 10k x 10k grid into a 100x100 grid:

![bokeh_plot - 2019-07-15T131812 114](https://user-images.githubusercontent.com/1550771/61212584-027d0900-a703-11e9-9bea-8597901cfdb2.png)

Here is the same, but this time the array isn't already in memory but loaded from disk with zarr:

![bokeh_plot - 2019-07-15T140555 076](https://user-images.githubusercontent.com/1550771/61214988-b7b2bf80-a709-11e9-938c-cf58385423cf.png)

Here we are zooming on a 50k x 50k (20 GB) array loaded with zarr (note how it slows down when we zoom out), while trying to minimize memory load:

![dask_zarr](https://user-images.githubusercontent.com/1550771/61217561-3ca0d780-a710-11e9-8457-436dc99c9327.gif)

### Known issues

- Upsampling with 'linear' interpolation does not yet use correct padding so boundaries are wrong

- [x] Add tests