### PR TITLE
Fix warnings with latest Numba

### DIFF
--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -33,9 +33,9 @@ def distance_between(a, b):
     return (((a[0] - b[0]) ** 2) + ((a[1] - b[1]) ** 2))**(0.5)
 
 
-@nb.jit
+@nb.jit(forceobj=True)
 def resample_segment(segments, new_segments, min_segment_length, max_segment_length, ndims):
-    next_point = np.array([0.0] * ndims)
+    next_point = np.zeros(ndims)
     current_point = segments[0]
     pos = 0
     index = 1
@@ -183,9 +183,8 @@ def get_gradients(img):
 
 class BaseSegment(object):
     @classmethod
-    @nb.jit
     def create_delimiter(cls):
-        return np.array([[np.nan] * cls.ndims])
+        return np.full((1, cls.ndims), np.nan)
 
 
 class UnweightedSegment(BaseSegment):
@@ -393,12 +392,11 @@ class connect_edges(param.ParameterizedFunction):
 
 directly_connect_edges = connect_edges # For bockwards compatibility; deprecated
 
-@nb.jit
+
 def minmax_normalize(X, lower, upper):
     return (X - lower) / (upper - lower)
 
 
-@nb.jit
 def minmax_denormalize(X, lower, upper):
     return X * (upper - lower) + lower
 

--- a/datashader/datatypes.py
+++ b/datashader/datatypes.py
@@ -551,7 +551,7 @@ Invalid indices for take with allow_fill True: {inds}""".format(
     @classmethod
     def _concat_same_type(cls, to_concat):
         # concat flat_arrays
-        flat_array = np.hstack(ra.flat_array for ra in to_concat)
+        flat_array = np.hstack([ra.flat_array for ra in to_concat])
 
         # offset and concat start_indices
         offsets = np.hstack([

--- a/datashader/geo.py
+++ b/datashader/geo.py
@@ -285,9 +285,9 @@ def mean(agg, passes=1, excludes=[np.nan]):
     out = None
     for i in range(passes):
         if out is None:
-            out = _mean(agg.data, excludes)
+            out = _mean(agg.data, tuple(excludes))
         else:
-            out = _mean(out, excludes)
+            out = _mean(out, tuple(excludes))
 
     return DataArray(out, dims=['y', 'x'], attrs=agg.attrs)
 
@@ -429,7 +429,7 @@ def bump(width, height, count=None, height_func=None, spread=1):
 
     bump_xs = np.random.choice(linx, count).tolist()
     bump_ys = np.random.choice(liny, count).tolist()
-    locs = list(zip(bump_xs, bump_ys))
+    locs = tuple(zip(bump_xs, bump_ys))
     heights = height_func(locs)
     bumps = _finish_bump(width, height, locs, heights, spread)
     return DataArray(bumps, dims=['y', 'x'], attrs=dict(res=1))

--- a/datashader/layout.py
+++ b/datashader/layout.py
@@ -171,7 +171,7 @@ def _merge_points_with_nodes(nodes, points, params):
     return n
 
 
-@nb.jit(nogil=True)
+@nb.jit(forceobj=True)
 def cooling(matrix, points, temperature, params):
     dt = temperature / float(params.iterations + 1)
     displacement = np.zeros((params.dim, len(points)))

--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -231,7 +231,7 @@ def _get_fill_value(fill_value, src, out):
     return fill_value
 
 
-@ngjit_parallel
+@ngjit
 def _get_dimensions(src, out):
     src_w = src.shape[-1]
     src_h = src.shape[-2]

--- a/datashader/spatial/points.py
+++ b/datashader/spatial/points.py
@@ -485,7 +485,7 @@ class SpatialPointsFrame(dd.DataFrame):
             self._distance_divisions = distance_divisions
 
             self._partition_grid = _build_partition_grid(
-                list(self._distance_divisions), self._p)
+                tuple(self._distance_divisions), self._p)
 
             # Compute derived properties
             n = 2

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -195,8 +195,8 @@ def test_auto_range_points():
     agg = cvs.points(ddf, 'x', 'y', ds.count('time'))
     sol = np.zeros((2*n, 2*n), int)
     np.fill_diagonal(sol, 1)
-    sol[[range(1, 4, 2)]] = 0
-    sol[[range(4, 8, 2)]] = 0
+    sol[[tuple(range(1, 4, 2))]] = 0
+    sol[[tuple(range(4, 8, 2))]] = 0
     np.testing.assert_equal(agg.data, sol)
 
     cvs = ds.Canvas(plot_width=2*n+1, plot_height=2*n+1)

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -648,7 +648,7 @@ def test_draw_triangle_nointerp():
     """Assert that we draw triangles properly, without interpolation enabled.
     """
     # Isosceles triangle
-    tri = [(2, 0), (0, 2), (4, 2)]
+    tri = ((2, 0), (0, 2), (4, 2))
     out = np.array([[0, 0, 1, 0, 0],
                     [0, 1, 1, 1, 0],
                     [1, 1, 1, 1, 1],
@@ -658,7 +658,7 @@ def test_draw_triangle_nointerp():
     np.testing.assert_equal(agg, out)
 
     # Right triangle
-    tri = [(2, 0), (0, 2), (2, 2)]
+    tri = ((2, 0), (0, 2), (2, 2))
     out = np.array([[0, 0, 2, 0, 0],
                     [0, 2, 2, 0, 0],
                     [2, 2, 2, 0, 0],
@@ -668,8 +668,8 @@ def test_draw_triangle_nointerp():
     np.testing.assert_equal(agg, out)
 
     # Two right trimesh
-    tri = [(2, 0), (1, 1), (2, 1),
-           (2, 1), (2, 2), (3, 2)]
+    tri = ((2, 0), (1, 1), (2, 1),
+           (2, 1), (2, 2), (3, 2))
     out = np.array([[0, 0, 3, 0, 0],
                     [0, 3, 6, 0, 0],
                     [0, 0, 3, 3, 0],
@@ -680,7 +680,7 @@ def test_draw_triangle_nointerp():
     np.testing.assert_equal(agg, out)
 
     # Draw isoc triangle with clipping
-    tri = [(2, 0), (0, 2), (4, 2)]
+    tri = ((2, 0), (0, 2), (4, 2))
     out = np.array([[0, 0, 1, 0, 0],
                     [0, 1, 1, 1, 0],
                     [1, 1, 1, 1, 0],
@@ -717,7 +717,7 @@ def test_draw_triangle_interp():
     """Assert that we draw triangles properly, with interpolation enabled.
     """
     # Isosceles triangle
-    tri = [(2, 0), (0, 2), (4, 2)]
+    tri = ((2, 0), (0, 2), (4, 2))
     out = np.array([[0, 0, 3, 0, 0],
                     [0, 3, 3, 3, 0],
                     [3, 3, 3, 3, 3],
@@ -726,7 +726,7 @@ def test_draw_triangle_interp():
     draw_triangle_interp(tri, (0, 4, 0, 5), (0, 0, 0), agg, (3, 3, 3))
     np.testing.assert_equal(agg, out)
 
-    tri = [(2, 0), (0, 2), (4, 2)]
+    tri = ((2, 0), (0, 2), (4, 2))
     out = np.array([[0, 0, 1, 0, 0],
                     [0, 1, 1, 2, 0],
                     [2, 2, 2, 2, 3],
@@ -735,7 +735,7 @@ def test_draw_triangle_interp():
     draw_triangle_interp(tri, (0, 4, 0, 5), (0, 0, 0), agg, (1, 2, 3))
     np.testing.assert_equal(agg, out)
 
-    tri = [(2, 0), (0, 2), (4, 2)]
+    tri = ((2, 0), (0, 2), (4, 2))
     out = np.array([[0, 0, 3, 0, 0],
                     [0, 4, 5, 6, 0],
                     [6, 6, 7, 8, 9],
@@ -744,7 +744,7 @@ def test_draw_triangle_interp():
     draw_triangle_interp(tri, (0, 4, 0, 5), (0, 0, 0), agg, (3, 6, 9))
     np.testing.assert_equal(agg, out)
 
-    tri = [(2, 0), (0, 2), (4, 2)]
+    tri = ((2, 0), (0, 2), (4, 2))
     out = np.array([[0, 0, 6, 0, 0],
                     [0, 5, 4, 4, 0],
                     [4, 3, 3, 2, 2],
@@ -758,9 +758,9 @@ def test_draw_triangle_subpixel():
     interpolation.
     """
     # With interpolation
-    tri = [(2, 0), (0, 2), (4, 2),
+    tri = ((2, 0), (0, 2), (4, 2),
            (2, 3), (2, 3), (2, 3),
-           (2, 3), (2, 3), (2, 3)]
+           (2, 3), (2, 3), (2, 3))
     out = np.array([[0, 0, 6, 0, 0],
                     [0, 5, 4, 4, 0],
                     [4, 3, 3, 2, 2],
@@ -772,9 +772,9 @@ def test_draw_triangle_subpixel():
     np.testing.assert_equal(agg, out)
 
     # Without interpolation
-    tri = [(2, 0), (0, 2), (4, 2),
+    tri = ((2, 0), (0, 2), (4, 2),
            (2, 3), (2, 3), (2, 3),
-           (2, 3), (2, 3), (2, 3)]
+           (2, 3), (2, 3), (2, 3))
     out = np.array([[0, 0, 2, 0, 0],
                     [0, 2, 2, 2, 0],
                     [2, 2, 2, 2, 2],

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -186,8 +186,8 @@ def test_auto_range_points():
     agg = cvs.points(df, 'x', 'y', ds.count('time'))
     sol = np.zeros((2*n, 2*n), int)
     np.fill_diagonal(sol, 1)
-    sol[[range(1, 4, 2)]] = 0
-    sol[[range(4, 8, 2)]] = 0
+    sol[[tuple(range(1, 4, 2))]] = 0
+    sol[[tuple(range(4, 8, 2))]] = 0
     np.testing.assert_equal(agg.data, sol)
 
     cvs = ds.Canvas(plot_width=2*n+1, plot_height=2*n+1)


### PR DESCRIPTION
Various fixes to datashader numba code to avoid the following warnings:

* Use correct JIT decorator for function which has no parallel target, avoiding a warning with latest numba versions.

* Avoid reflected list deprecation warnings, mostly by passing in tuples instead

* Declare forceobj mode for functions which don't support nopython and looplifting.