### PR TITLE
Implemented QuadMesh resampling

### DIFF
--- a/datashader/core.py
+++ b/datashader/core.py
@@ -969,7 +969,6 @@ The axis argument to Canvas.line must be 0 or 1
             xarr = (xscaled[xm0:xm1+1] * self.plot_width).astype(int)
             yarr = (yscaled[ym0:ym1+1] * self.plot_height).astype(int)
             zs = zs[ym0:ym1, xm0:xm1]
-            mask = None
         else:
             x = (xscaled * self.plot_width).astype(int)
             y = (yscaled * self.plot_height).astype(int)

--- a/datashader/resampling.py
+++ b/datashader/resampling.py
@@ -965,7 +965,7 @@ def infer_interval_breaks(coord, axis=0):
     array([-0.5,  0.5,  1.5,  2.5,  3.5,  4.5])
     >>> infer_interval_breaks([[0, 1], [3, 4]], axis=1)
     array([[-0.5,  0.5,  1.5],
-    [ 2.5,  3.5,  4.5]])
+           [ 2.5,  3.5,  4.5]])
     """
     coord = np.asarray(coord)
     if sys.version_info.major == 2 and len(coord) and isinstance(coord[0], (dt.datetime, dt.date)):


### PR DESCRIPTION
Implements resampling of recti- and curvi-linear QuadMeshes. The input for the rectilinear case can be a xr.DataArray or xr.Dataset and for the curvilinear case must be a xr.Dataset. Compared to the approach in HoloViews which creates an intermediate trimesh from a quadmesh this represents a 600-700x speedup for the rectilinear case and a 17x speedup in the curvilinear case.   

- [x] Implement rectilinear resampling
- [x] Implement curvilinear resampling
- [ ] Implement aggregators
  - [x] count
  - [x] sum
  - [x] mean
  - [x] first
  - [x] last
  - [x] min
  - [x] max
  - [ ] std?
  - [ ] var?
  - [ ] mode?
- [ ] Implement distributed version?
- [ ] Add examples/docs
- [ ] Add tests