### PR TITLE
Refactor compiler's make_append to handle more than one dimension

### DIFF
--- a/datashader/glyphs/area.py
+++ b/datashader/glyphs/area.py
@@ -16,6 +16,10 @@ class _AreaToLineLike(Glyph):
         self.y_stack = y_stack
 
     @property
+    def ndims(self):
+        return 1
+
+    @property
     def inputs(self):
         return (self.x, self.y, self.y_stack)
 

--- a/datashader/glyphs/glyph.py
+++ b/datashader/glyphs/glyph.py
@@ -6,6 +6,21 @@ from datashader.utils import Expr, ngjit
 
 class Glyph(Expr):
     """Base class for glyphs."""
+
+    @property
+    def ndims(self):
+        """
+        The number of dimensions required in the data structure this Glyph is
+        constructed from. Or None if input data structure is irregular
+
+        For example
+         * ndims is 1 if glyph is constructed from a DataFrame
+         * ndims is 2 if glyph is constructed from a 2D xarray DataArray
+         * ndims is None if glyph is constructed from multiple DataFrames of
+           different lengths
+        """
+        raise NotImplementedError()
+
     @staticmethod
     def maybe_expand_bounds(bounds):
         minval, maxval = bounds

--- a/datashader/glyphs/points.py
+++ b/datashader/glyphs/points.py
@@ -13,6 +13,10 @@ class _PointLike(Glyph):
         self.y = y
 
     @property
+    def ndims(self):
+        return 1
+
+    @property
     def inputs(self):
         return (self.x, self.y)
 

--- a/datashader/glyphs/trimesh.py
+++ b/datashader/glyphs/trimesh.py
@@ -25,6 +25,10 @@ class _PolygonLike(_PointLike):
         self.weight_type = weight_type
 
     @property
+    def ndims(self):
+        return None
+
+    @property
     def inputs(self):
         return (tuple([self.x, self.y] + list(self.z)) +
                 (self.weight_type, self.interpolate))
@@ -89,7 +93,7 @@ def _build_draw_triangle(append):
         w0, w1, w2 = weights
         if minx == maxx and miny == maxy:
             # Subpixel case; area == 0
-            append(minx, miny, aggs, (w0 + w1 + w2) / 3)
+            append(minx, miny, *(aggs + ((w0 + w1 + w2) / 3,)))
         else:
             (ax, ay), (bx, by), (cx, cy) = verts
             bias0, bias1, bias2 = biases
@@ -101,7 +105,7 @@ def _build_draw_triangle(append):
                     g1 = edge_func(cx, cy, ax, ay, i, j)
                     if ((g2 + bias0) | (g0 + bias1) | (g1 + bias2)) >= 0:
                         interp_res = (g0 * w0 + g1 * w1 + g2 * w2) / area
-                        append(i, j, aggs, interp_res)
+                        append(i, j, *(aggs + (interp_res,)))
 
     @ngjit
     def draw_triangle(verts, bbox, biases, aggs, val):
@@ -114,7 +118,7 @@ def _build_draw_triangle(append):
         minx, maxx, miny, maxy = bbox
         if minx == maxx and miny == maxy:
             # Subpixel case; area == 0
-            append(minx, miny, aggs, val)
+            append(minx, miny, *(aggs + (val,)))
         else:
             (ax, ay), (bx, by), (cx, cy) = verts
             bias0, bias1, bias2 = biases
@@ -123,7 +127,7 @@ def _build_draw_triangle(append):
                     if ((edge_func(ax, ay, bx, by, i, j) + bias0) >= 0 and
                             (edge_func(bx, by, cx, cy, i, j) + bias1) >= 0 and
                             (edge_func(cx, cy, ax, ay, i, j) + bias2) >= 0):
-                        append(i, j, aggs, val)
+                        append(i, j, *(aggs + (val,)))
 
 
     return draw_triangle, draw_triangle_interp

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -661,7 +661,7 @@ def test_draw_triangle_nointerp():
                     [1, 1, 1, 1, 1],
                     [0, 0, 0, 0, 0]])
     agg = np.zeros((4, 5), dtype='i4')
-    draw_triangle(tri, (0, 4, 0, 5), (0, 0, 0), agg, 1)
+    draw_triangle(tri, (0, 4, 0, 5), (0, 0, 0), (agg,), 1)
     np.testing.assert_equal(agg, out)
 
     # Right triangle
@@ -671,7 +671,7 @@ def test_draw_triangle_nointerp():
                     [2, 2, 2, 0, 0],
                     [0, 0, 0, 0, 0]])
     agg = np.zeros((4, 5), dtype='i4')
-    draw_triangle(tri, (0, 4, 0, 5), (0, 0, 0), agg, 2)
+    draw_triangle(tri, (0, 4, 0, 5), (0, 0, 0), (agg,), 2)
     np.testing.assert_equal(agg, out)
 
     # Two right trimesh
@@ -682,8 +682,8 @@ def test_draw_triangle_nointerp():
                     [0, 0, 3, 3, 0],
                     [0, 0, 0, 0, 0]])
     agg = np.zeros((4, 5), dtype='i4')
-    draw_triangle(tri[:3], (0, 4, 0, 5), (0, 0, 0), agg, 3)
-    draw_triangle(tri[3:], (0, 4, 0, 5), (0, 0, 0), agg, 3)
+    draw_triangle(tri[:3], (0, 4, 0, 5), (0, 0, 0), (agg,), 3)
+    draw_triangle(tri[3:], (0, 4, 0, 5), (0, 0, 0), (agg,), 3)
     np.testing.assert_equal(agg, out)
 
     # Draw isoc triangle with clipping
@@ -693,7 +693,7 @@ def test_draw_triangle_nointerp():
                     [1, 1, 1, 1, 0],
                     [0, 0, 0, 0, 0]])
     agg = np.zeros((4, 5), dtype='i4')
-    draw_triangle(tri, (0, 3, 0, 2), (0, 0, 0), agg, 1)
+    draw_triangle(tri, (0, 3, 0, 2), (0, 0, 0), (agg,), 1)
     np.testing.assert_equal(agg, out)
     # clip from right and left
     out = np.array([[0, 0, 1, 0, 0],
@@ -701,7 +701,7 @@ def test_draw_triangle_nointerp():
                     [0, 1, 1, 1, 0],
                     [0, 0, 0, 0, 0]])
     agg = np.zeros((4, 5), dtype='i4')
-    draw_triangle(tri, (1, 3, 0, 2), (0, 0, 0), agg, 1)
+    draw_triangle(tri, (1, 3, 0, 2), (0, 0, 0), (agg,), 1)
     np.testing.assert_equal(agg, out)
     # clip from right, left, top
     out = np.array([[0, 0, 0, 0, 0],
@@ -709,7 +709,7 @@ def test_draw_triangle_nointerp():
                     [0, 1, 1, 1, 0],
                     [0, 0, 0, 0, 0]])
     agg = np.zeros((4, 5), dtype='i4')
-    draw_triangle(tri, (1, 3, 1, 2), (0, 0, 0), agg, 1)
+    draw_triangle(tri, (1, 3, 1, 2), (0, 0, 0), (agg,), 1)
     np.testing.assert_equal(agg, out)
     # clip from right, left, top, bottom
     out = np.array([[0, 0, 0, 0, 0],
@@ -717,7 +717,7 @@ def test_draw_triangle_nointerp():
                     [0, 0, 0, 0, 0],
                     [0, 0, 0, 0, 0]])
     agg = np.zeros((4, 5), dtype='i4')
-    draw_triangle(tri, (1, 3, 1, 1), (0, 0, 0), agg, 1)
+    draw_triangle(tri, (1, 3, 1, 1), (0, 0, 0), (agg,), 1)
     np.testing.assert_equal(agg, out)
 
 def test_draw_triangle_interp():
@@ -730,7 +730,7 @@ def test_draw_triangle_interp():
                     [3, 3, 3, 3, 3],
                     [0, 0, 0, 0, 0]])
     agg = np.zeros((4, 5), dtype='i4')
-    draw_triangle_interp(tri, (0, 4, 0, 5), (0, 0, 0), agg, (3, 3, 3))
+    draw_triangle_interp(tri, (0, 4, 0, 5), (0, 0, 0), (agg,), (3, 3, 3))
     np.testing.assert_equal(agg, out)
 
     tri = ((2, 0), (0, 2), (4, 2))
@@ -739,7 +739,7 @@ def test_draw_triangle_interp():
                     [2, 2, 2, 2, 3],
                     [0, 0, 0, 0, 0]])
     agg = np.zeros((4, 5), dtype='i4')
-    draw_triangle_interp(tri, (0, 4, 0, 5), (0, 0, 0), agg, (1, 2, 3))
+    draw_triangle_interp(tri, (0, 4, 0, 5), (0, 0, 0), (agg,), (1, 2, 3))
     np.testing.assert_equal(agg, out)
 
     tri = ((2, 0), (0, 2), (4, 2))
@@ -748,7 +748,7 @@ def test_draw_triangle_interp():
                     [6, 6, 7, 8, 9],
                     [0, 0, 0, 0, 0]])
     agg = np.zeros((4, 5), dtype='i4')
-    draw_triangle_interp(tri, (0, 4, 0, 5), (0, 0, 0), agg, (3, 6, 9))
+    draw_triangle_interp(tri, (0, 4, 0, 5), (0, 0, 0), (agg,), (3, 6, 9))
     np.testing.assert_equal(agg, out)
 
     tri = ((2, 0), (0, 2), (4, 2))
@@ -757,7 +757,7 @@ def test_draw_triangle_interp():
                     [4, 3, 3, 2, 2],
                     [0, 0, 0, 0, 0]])
     agg = np.zeros((4, 5), dtype='i4')
-    draw_triangle_interp(tri, (0, 4, 0, 5), (0, 0, 0), agg, (6, 4, 2))
+    draw_triangle_interp(tri, (0, 4, 0, 5), (0, 0, 0), (agg,), (6, 4, 2))
     np.testing.assert_equal(agg, out)
 
 def test_draw_triangle_subpixel():
@@ -773,9 +773,9 @@ def test_draw_triangle_subpixel():
                     [4, 3, 3, 2, 2],
                     [0, 0, 8, 0, 0]])
     agg = np.zeros((4, 5), dtype='i4')
-    draw_triangle_interp(tri[:3], (0, 4, 0, 5), (0, 0, 0), agg, (6, 4, 2))
-    draw_triangle_interp(tri[3:6], (2, 2, 3, 3), (0, 0, 0), agg, (6, 4, 2))
-    draw_triangle_interp(tri[6:], (2, 2, 3, 3), (0, 0, 0), agg, (6, 4, 2))
+    draw_triangle_interp(tri[:3], (0, 4, 0, 5), (0, 0, 0), (agg,), (6, 4, 2))
+    draw_triangle_interp(tri[3:6], (2, 2, 3, 3), (0, 0, 0), (agg,), (6, 4, 2))
+    draw_triangle_interp(tri[6:], (2, 2, 3, 3), (0, 0, 0), (agg,), (6, 4, 2))
     np.testing.assert_equal(agg, out)
 
     # Without interpolation
@@ -787,9 +787,9 @@ def test_draw_triangle_subpixel():
                     [2, 2, 2, 2, 2],
                     [0, 0, 4, 0, 0]])
     agg = np.zeros((4, 5), dtype='i4')
-    draw_triangle(tri[:3], (0, 4, 0, 5), (0, 0, 0), agg, 2)
-    draw_triangle(tri[3:6], (2, 2, 3, 3), (0, 0, 0), agg, 2)
-    draw_triangle(tri[6:], (2, 2, 3, 3), (0, 0, 0), agg, 2)
+    draw_triangle(tri[:3], (0, 4, 0, 5), (0, 0, 0), (agg,), 2)
+    draw_triangle(tri[3:6], (2, 2, 3, 3), (0, 0, 0), (agg,), 2)
+    draw_triangle(tri[6:], (2, 2, 3, 3), (0, 0, 0), (agg,), 2)
     np.testing.assert_equal(agg, out)
 
 


### PR DESCRIPTION
This PR is a small refactor to the `make_append` function in the compiler module.  Previously, this function assumed that the input data structure for all glyphs was 1-dimensions (e.g. a DataFrame).  Because `trimesh` doesn't fit this assumption, there was special-casing logic in `make_append` to check if the glyph was a `Triangle`.

With this PR, each glyph has an `ndims` property that indicates the number of dimensions required to index into the data structure that the glyph is built from.  Currently, this value is 1 for all of the glyph except Triangle, in which case it is `None`.

When quadmesh is added, it will have an `ndims` value of 2. If the raster functionality is ported to the glyph framework, then it would have an `ndims` value of 2 as well. 
