### PR TITLE
[WIP] Add quadmesh glyph

### DIFF
--- a/datashader/__init__.py
+++ b/datashader/__init__.py
@@ -12,6 +12,7 @@ from .pipeline import Pipeline                           # noqa (API import)
 from . import transfer_functions as tf                   # noqa (API import)
 
 from . import pandas                         # noqa (build backend dispatch)
+from . import xarray                         # noqa (build backend dispatch)
 try:
     from . import dask                       # noqa (build backend dispatch)
 except ImportError:

--- a/datashader/core.py
+++ b/datashader/core.py
@@ -11,7 +11,8 @@ from xarray import DataArray, Dataset
 from collections import OrderedDict
 
 from datashader.spatial.points import SpatialPointsFrame
-from .utils import Dispatcher, ngjit, calc_res, calc_bbox, orient_array, compute_coords
+from .utils import Dispatcher, ngjit, calc_res, calc_bbox, orient_array, \
+    compute_coords, dshape_from_xarray_dataset
 from .utils import get_indices, dshape_from_pandas, dshape_from_dask
 from .utils import Expr # noqa (API import)
 from .resampling import resample_2d, resample_2d_distributed
@@ -564,6 +565,75 @@ The axis argument to Canvas.line must be 0 or 1
 
         return bypixel(source, self, glyph, agg)
 
+    def quadmesh(self, source, x=None, y=None, agg=None):
+        """Samples a recti- or curvi-linear quadmesh by canvas size and bounds.
+        Parameters
+        ----------
+        source : xarray.DataArray or Dataset
+            The input datasource.
+        x, y : str
+            Column names for the x and y coordinates of each point.
+        agg : Reduction, optional
+            Reduction to compute. Default is ``mean()``.
+        Returns
+        -------
+        data : xarray.DataArray
+        """
+        from .glyphs import QuadMeshRectilinear, QuadMeshCurvialinear
+
+        # Determine reduction operation
+        from .reductions import mean as mean_rnd
+
+        if isinstance(source, Dataset):
+            if agg is None or agg.column is None:
+                name = list(source.data_vars)[0]
+            else:
+                name = agg.column
+            # Keep as dataset so that source[agg.column] works
+            source = source[[name]]
+        elif isinstance(source, DataArray):
+            # Make dataset so that source[agg.column] works
+            name = source.name
+            source = source.to_dataset()
+        else:
+            raise ValueError("Invalid input type")
+
+        if agg is None:
+            agg = mean_rnd(name)
+
+        if x is None and y is None:
+            y, x = source.dims
+        elif not x or not y:
+            raise ValueError("Either specify both x and y coordinates"
+                             "or allow them to be inferred.")
+        yarr, xarr = source[y], source[x]
+
+        if (yarr.ndim > 1 or xarr.ndim > 1) and xarr.dims != yarr.dims:
+            raise ValueError("Ensure that x- and y-coordinate arrays "
+                             "share the same dimensions. x-coordinates "
+                             "are indexed by %s dims while "
+                             "y-coordinates are indexed by %s dims." %
+                             (xarr.dims, yarr.dims))
+
+        if (name is not None
+                and agg.column is not None
+                and agg.column != name):
+            raise ValueError('DataArray name %r does not match '
+                             'supplied reduction %s.' %
+                             (source.name, agg))
+
+        if xarr.ndim == 1:
+            glyph = QuadMeshRectilinear(x, y, name)
+        elif xarr.ndim == 2:
+            glyph = QuadMeshCurvialinear(x, y, name)
+        else:
+            raise ValueError("""\
+x- and y-coordinate arrays must have 1 or 2 dimensions.
+    Received arrays with dimensions: {dims}""".format(
+                dims=list(xarr.dims)))
+
+        return bypixel(source, self, glyph, agg)
+
     # TODO re 'untested', below: Consider replacing with e.g. a 3x3
     # array in the call to Canvas (plot_height=3,plot_width=3), then
     # show the output as a numpy array that has a compact
@@ -910,11 +980,13 @@ def bypixel(source, canvas, glyph, agg):
     glyph : Glyph
     agg : Reduction
     """
-    if isinstance(source, DataArray):
+
+    # Convert 1D xarray DataArrays and DataSets into Dask DataFrames
+    if isinstance(source, DataArray) and source.ndim == 1:
         if not source.name:
             source.name = 'value'
         source = source.reset_coords()
-    if isinstance(source, Dataset):
+    if isinstance(source, Dataset) and len(source.dims) == 1:
         columns = list(source.coords.keys()) + list(source.data_vars.keys())
         cols_to_keep = _cols_to_keep(columns, glyph, agg)
         source = source.drop([col for col in columns if col not in cols_to_keep])
@@ -931,6 +1003,9 @@ def bypixel(source, canvas, glyph, agg):
         dshape = dshape_from_pandas(source)
     elif isinstance(source, dd.DataFrame):
         dshape = dshape_from_dask(source)
+    elif isinstance(source, Dataset):
+        # Multi-dimensional Dataset
+        dshape = dshape_from_xarray_dataset(source)
     else:
         raise ValueError("source must be a pandas or dask DataFrame")
     schema = dshape.measure

--- a/datashader/glyphs/__init__.py
+++ b/datashader/glyphs/__init__.py
@@ -23,4 +23,7 @@ from .area import (  # noqa (API import)
     AreaToLineAxis1Ragged,
 )
 from .trimesh import Triangles  # noqa (API import)
+from .quadmesh import (  # noqa (API import)
+    QuadMeshRectilinear, QuadMeshCurvialinear
+)
 from .glyph import Glyph  # noqa (API import)

--- a/datashader/glyphs/quadmesh.py
+++ b/datashader/glyphs/quadmesh.py
@@ -1,0 +1,123 @@
+from toolz import memoize
+
+from datashader.glyphs.glyph import Glyph
+from datashader.resampling import infer_interval_breaks
+from datashader.utils import isreal, ngjit
+
+
+class _QuadMeshLike(Glyph):
+    def __init__(self, x, y, name):
+        self.x = x
+        self.y = y
+        self.name = name
+
+    @property
+    def ndims(self):
+        return 2
+
+    @property
+    def inputs(self):
+        return (self.x, self.y, self.name)
+
+    def validate(self, in_dshape):
+        if not isreal(in_dshape.measure[str(self.x)]):
+            raise ValueError('x must be real')
+        elif not isreal(in_dshape.measure[str(self.y)]):
+            raise ValueError('y must be real')
+        elif not isreal(in_dshape.measure[str(self.name)]):
+            raise ValueError('aggregate value must be real')
+
+    @property
+    def x_label(self):
+        return self.x
+
+    @property
+    def y_label(self):
+        return self.y
+
+
+class QuadMeshRectilinear(_QuadMeshLike):
+    def _compute_bounds_from_1d_centers(self, xr_ds, dim):
+        vals = xr_ds[dim].values
+
+        # Assume dimension is sorted in ascending or descending order
+        v0, v1, v_nm1, v_n = [
+            vals[i] for i in [0, 1, -2, -1]
+        ]
+
+        # Check if we should swap order
+        if v_n < v0:
+            v0, v1, v_nm1, v_n = v_n, v_nm1, v1, v0
+
+        bounds = (v0 - 0.5 * (v1 - v0), v_n + 0.5 * (v_n - v_nm1))
+        return self.maybe_expand_bounds(bounds)
+
+    def compute_x_bounds(self, xr_ds):
+        return self._compute_bounds_from_1d_centers(xr_ds, self.x)
+
+    def compute_y_bounds(self, xr_ds):
+        return self._compute_bounds_from_1d_centers(xr_ds, self.y)
+
+    @memoize
+    def _build_extend(self, x_mapper, y_mapper, info, append):
+        x_name = self.x
+        y_name = self.y
+
+        @ngjit
+        def _extend(vt, bounds, xs, ys, *aggs_and_cols):
+            sx, tx, sy, ty = vt
+            xmin, xmax, ymin, ymax = bounds
+
+            # Compute max valid x and y index
+            xmaxi = int(round(x_mapper(xmax) * sx + tx))
+            ymaxi = int(round(y_mapper(ymax) * sy + ty))
+
+            for i in range(len(xs) - 1):
+                for j in range(len(ys) - 1):
+                    x0, x1 = max(xs[i], xmin), min(xs[i + 1], xmax)
+                    y0, y1 = max(ys[j], ymin), min(ys[j + 1], ymax)
+
+                    # Makes sure x0 <= x1 and y0 <= y1
+                    if x0 > x1:
+                        x0, x1 = x1, x0
+                    if y0 > y1:
+                        y0, y1 = y1, y0
+
+                    # check whether we can skip quad. To avoid overlapping
+                    # quads, skip if upper bound equals viewport lower bound.
+                    if x1 <= xmin or x0 > xmax or y1 <= ymin or y0 > ymax:
+                        continue
+
+                    # Map onto pixels and clip to viewport
+                    x0i = max(int(x_mapper(x0) * sx + tx), 0)
+                    x1i = min(int(x_mapper(x1) * sx + tx), xmaxi)
+                    y0i = max(int(y_mapper(y0) * sy + ty), 0)
+                    y1i = min(int(y_mapper(y1) * sy + ty), ymaxi)
+
+                    # Make sure single pixel quads are represented
+                    if x0i == x1i and x1i < ymaxi:
+                        x1i += 1
+
+                    if y0i == y1i and y1i < ymaxi:
+                        y1i += 1
+
+                    # x1i and y1i are not included in the iteration. this
+                    # serves to avoid overlapping quads and it avoids the need
+                    # for special handling of quads that end on exactly on the
+                    # upper bound.
+                    for xi in range(x0i, x1i):
+                        for yi in range(y0i, y1i):
+                            append(j, i, xi, yi, *aggs_and_cols)
+
+        def extend(aggs, xr_ds, vt, bounds):
+            # Convert from bin centers to interval edges
+            xs = infer_interval_breaks(xr_ds[x_name].values)
+            ys = infer_interval_breaks(xr_ds[y_name].values)
+            cols = aggs + info(xr_ds.transpose(y_name, x_name))
+            _extend(vt, bounds, xs, ys, *cols)
+
+        return extend
+
+
+class QuadMeshCurvialinear(_QuadMeshLike):
+    pass

--- a/datashader/pandas.py
+++ b/datashader/pandas.py
@@ -21,7 +21,7 @@ glyph_dispatch = Dispatcher()
 
 @glyph_dispatch.register(_PointLike)
 @glyph_dispatch.register(_AreaToLineLike)
-def pointlike(glyph, df, schema, canvas, summary):
+def default(glyph, df, schema, canvas, summary):
     create, info, append, _, finalize = compile_components(summary, schema, glyph)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper

--- a/datashader/tests/test_quadmesh.py
+++ b/datashader/tests/test_quadmesh.py
@@ -1,0 +1,127 @@
+import numpy as np
+from numpy import nan
+import xarray as xr
+import datashader as ds
+
+
+def test_rect_quadmesh_autorange():
+    c = ds.Canvas(plot_width=8, plot_height=4)
+    da = xr.DataArray(
+        [[1, 2, 3, 4],
+         [5, 6, 7, 8]],
+        coords=[('b', [1, 2]),
+                ('a', [1, 2, 3, 4])],
+        name='Z')
+
+    y_coords = np.linspace(0.75, 2.25, 4)
+    x_coords = np.linspace(0.75, 4.25, 8)
+    out = xr.DataArray(np.array(
+        [[1., 1., 2., 2., 3., 3., 4., 4.],
+         [1., 1., 2., 2., 3., 3., 4., 4.],
+         [5., 5., 6., 6., 7., 7., 8., 8.],
+         [5., 5., 6., 6., 7., 7., 8., 8.]],
+        dtype='i4'),
+        coords=[('b', y_coords),
+                ('a', x_coords)]
+    )
+
+    res = c.quadmesh(da, x='a', y='b', agg=ds.sum('Z'))
+    assert res.equals(out)
+
+    # Check transpose gives same answer
+    res = c.quadmesh(da.transpose('a', 'b'), x='a', y='b', agg=ds.sum('Z'))
+    assert res.equals(out)
+
+
+def test_rect_quadmesh_autorange_reversed():
+    c = ds.Canvas(plot_width=8, plot_height=4)
+    da = xr.DataArray(
+        [[1, 2, 3, 4],
+         [5, 6, 7, 8]],
+        coords=[('b', [-1, -2]),
+                ('a', [-1, -2, -3, -4])],
+        name='Z')
+
+    y_coords = np.linspace(-2.25, -0.75, 4)
+    x_coords = np.linspace(-4.25, -0.75, 8)
+    out = xr.DataArray(np.array(
+        [[8., 8., 7., 7., 6., 6., 5., 5.],
+         [8., 8., 7., 7., 6., 6., 5., 5.],
+         [4., 4., 3., 3., 2., 2., 1., 1.],
+         [4., 4., 3., 3., 2., 2., 1., 1.]],
+        dtype='i4'),
+        coords=[('b', y_coords),
+                ('a', x_coords)]
+    )
+
+    res = c.quadmesh(da, x='a', y='b', agg=ds.sum('Z'))
+    print(res)
+    assert res.equals(out)
+
+    # Check transpose gives same answer
+    res = c.quadmesh(da.transpose('a', 'b'), x='a', y='b', agg=ds.sum('Z'))
+    assert res.equals(out)
+
+
+def test_rect_quadmesh_manual_range():
+    c = ds.Canvas(plot_width=8, plot_height=4,
+                  x_range=[1, 3],
+                  y_range=[-1, 3])
+
+    da = xr.DataArray(
+        [[1, 2, 3, 4],
+         [5, 6, 7, 8]],
+        coords=[('b', [1, 2]),
+                ('a', [1, 2, 3, 4])],
+        name='Z')
+
+    y_coords = np.linspace(-0.5, 2.5, 4)
+    x_coords = np.linspace(1.125, 2.875, 8)
+    out = xr.DataArray(np.array(
+        [[nan, nan, nan, nan, nan, nan, nan, nan],
+         [1., 1., 2., 2., 2., 2., 3., 3.],
+         [5., 5., 6., 6., 6., 6., 7., 7.],
+         [nan, nan, nan, nan, nan, nan, nan, nan]],
+        dtype='f4'),
+        coords=[('b', y_coords),
+                ('a', x_coords)]
+    )
+
+    res = c.quadmesh(da, x='a', y='b', agg=ds.sum('Z'))
+    assert res.equals(out)
+
+    # Check transpose gives same answer
+    res = c.quadmesh(da.transpose('a', 'b'), x='a', y='b', agg=ds.sum('Z'))
+    assert res.equals(out)
+
+
+def test_subpixel_quads_represented():
+    c = ds.Canvas(plot_width=8, plot_height=4,
+                  x_range=[0, 16],
+                  y_range=[0, 8])
+
+    da = xr.DataArray(
+        [[1, 2, 3, 4],
+         [5, 6, 7, 8]],
+        coords=[('b', [1, 2]),
+                ('a', [1, 2, 3, 4])],
+        name='Z')
+
+    y_coords = np.linspace(1, 7, 4)
+    x_coords = np.linspace(1, 15, 8)
+    out = xr.DataArray(np.array(
+        [[14., 22., nan, nan, nan, nan, nan, nan],
+         [nan, nan, nan, nan, nan, nan, nan, nan],
+         [nan, nan, nan, nan, nan, nan, nan, nan],
+         [nan, nan, nan, nan, nan, nan, nan, nan]],
+        dtype='f4'),
+        coords=[('b', y_coords),
+                ('a', x_coords)]
+    )
+
+    res = c.quadmesh(da, x='a', y='b', agg=ds.sum('Z'))
+    assert res.equals(out)
+
+    # Check transpose gives same answer
+    res = c.quadmesh(da.transpose('a', 'b'), x='a', y='b', agg=ds.sum('Z'))
+    assert res.equals(out)

--- a/datashader/utils.py
+++ b/datashader/utils.py
@@ -394,6 +394,14 @@ def dshape_from_dask(df):
     return datashape.var * dshape_from_pandas(df.head()).measure
 
 
+def dshape_from_xarray_dataset(xr_ds):
+    """Return a datashape.DataShape object given a xarray Dataset."""
+    return datashape.var * datashape.Record([
+        (k, dshape_from_pandas_helper(xr_ds[k]))
+        for k in list(xr_ds.data_vars) + list(xr_ds.coords)
+    ])
+
+
 def dataframe_from_multiple_sequences(x_values, y_values):
    """
    Converts a set of multiple sequences (eg: time series), stored as a 2 dimensional

--- a/datashader/xarray.py
+++ b/datashader/xarray.py
@@ -1,0 +1,18 @@
+from datashader.compiler import compile_components
+from datashader.glyphs.quadmesh import _QuadMeshLike
+from datashader.pandas import default
+from .core import bypixel
+import xarray as xr
+from .utils import Dispatcher
+
+
+glyph_dispatch = Dispatcher()
+
+
+@bypixel.pipeline.register(xr.Dataset)
+def xarray_pipeline(df, schema, canvas, glyph, summary):
+    return glyph_dispatch(glyph, df, schema, canvas, summary)
+
+
+# Default to default pandas implementation
+glyph_dispatch.register(_QuadMeshLike)(default)


### PR DESCRIPTION
This PR is an alternative implementation of quadmesh rasterization, roughly based on the logic from https://github.com/pyviz/datashader/pull/769.  So far only the rectilinear case is implemented.

Unlike that PR, this PR adds quadmesh glyph classes, and supports the standard datashader aggregation framework.

Overall, the architecture fits well with that of the dataframe-based glyphs (points, line, and area). And relying on the datashader aggregation framework results in a lot less code duplication compared to https://github.com/pyviz/datashader/pull/769.

**But**, it's an order of magnitude slower than the implementations in https://github.com/pyviz/datashader/pull/769.  Here is a notebook showing some timing results: https://anaconda.org/jonmmease/rectquadmesh_examples/notebook.

Roughly speaking, this PR is ~13x faster than representing a rectilinear quadmesh with a trimesh. But the specialized implementation from https://github.com/pyviz/datashader/pull/769 is ~13 faster than this PR.  Note that I disabled numba parallelization for these tests for consistency

I did some performance debugging and I found that nearly all of the extra overhead in this PR, compared to the specialized implementation, is coming from the use of the aggregation framework.  If in the `_extend` function, I don't call `append` but instead implement a single aggregation then the performance is comparable to the specialized implementations.

So the bad news is that right now we need to choose between performance and consistency/maintainability for the quadmesh implementation.  The good news is that there may be an order of magnitude speedup to be had across `points`, `line`, and `area` glyphs as well if we can work out how to optimize the aggregation framework.

@jbednar @philippjfr 
