### PR TITLE
Glyph rendering optimization using variable length argument expansion

### DIFF
--- a/datashader/geo.py
+++ b/datashader/geo.py
@@ -3,7 +3,7 @@ This module contains geoscience-related transfer functions whose use is complete
 
 """
 
-from __future__ import division
+from __future__ import division, absolute_import
 
 import numpy as np
 import datashader.transfer_functions as tf

--- a/datashader/glyphs/area.py
+++ b/datashader/glyphs/area.py
@@ -89,10 +89,14 @@ class AreaToZeroAxis0(_PointLike):
 
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        expand_aggs_and_cols = self.expand_aggs_and_cols(append)
+        draw_trapezoid_y = _build_draw_trapezoid_y(
+            append, expand_aggs_and_cols
+        )
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         extend_area = _build_extend_area_to_zero_axis0(
-            draw_trapezoid_y, map_onto_pixel)
+            draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+        )
         x_name = self.x
         y_name = self.y
 
@@ -154,10 +158,12 @@ class AreaToLineAxis0(_AreaToLineLike):
 
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        expand_aggs_and_cols = self.expand_aggs_and_cols(append)
+        draw_trapezoid_y = _build_draw_trapezoid_y(append, expand_aggs_and_cols)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         extend_area = _build_extend_area_to_line_axis0(
-            draw_trapezoid_y, map_onto_pixel)
+            draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+        )
         x_name = self.x
         y_name = self.y
         y_stack_name = self.y_stack
@@ -229,10 +235,12 @@ class AreaToZeroAxis0Multi(_PointLike):
 
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        expand_aggs_and_cols = self.expand_aggs_and_cols(append)
+        draw_trapezoid_y = _build_draw_trapezoid_y(append, expand_aggs_and_cols)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         extend_area = _build_extend_area_to_zero_axis0_multi(
-            draw_trapezoid_y, map_onto_pixel)
+            draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+        )
         x_names = self.x
         y_names = self.y
 
@@ -302,10 +310,12 @@ class AreaToLineAxis0Multi(_AreaToLineLike):
 
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        expand_aggs_and_cols = self.expand_aggs_and_cols(append)
+        draw_trapezoid_y = _build_draw_trapezoid_y(append, expand_aggs_and_cols)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         extend_area = _build_extend_area_to_line_axis0_multi(
-            draw_trapezoid_y, map_onto_pixel)
+            draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+        )
         x_names = self.x
         y_names = self.y
         y_stack_names = self.y_stack
@@ -393,10 +403,12 @@ class AreaToZeroAxis1(_PointLike):
 
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        expand_aggs_and_cols = self.expand_aggs_and_cols(append)
+        draw_trapezoid_y = _build_draw_trapezoid_y(append, expand_aggs_and_cols)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         extend_area = _build_extend_area_to_zero_axis1_none_constant(
-            draw_trapezoid_y, map_onto_pixel)
+            draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+        )
 
         x_names = self.x
         y_names = self.y
@@ -486,10 +498,12 @@ class AreaToLineAxis1(_AreaToLineLike):
 
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        expand_aggs_and_cols = self.expand_aggs_and_cols(append)
+        draw_trapezoid_y = _build_draw_trapezoid_y(append, expand_aggs_and_cols)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         extend_area = _build_extend_area_to_line_axis1_none_constant(
-            draw_trapezoid_y, map_onto_pixel)
+            draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+        )
         x_names = self.x
         y_names = self.y
         y_stack_names = self.y_stack
@@ -539,10 +553,12 @@ class AreaToZeroAxis1XConstant(AreaToZeroAxis1):
 
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        expand_aggs_and_cols = self.expand_aggs_and_cols(append)
+        draw_trapezoid_y = _build_draw_trapezoid_y(append, expand_aggs_and_cols)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         extend_area = _build_extend_area_to_zero_axis1_x_constant(
-            draw_trapezoid_y, map_onto_pixel)
+            draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+        )
 
         x_values = self.x
         y_names = self.y
@@ -603,10 +619,12 @@ class AreaToLineAxis1XConstant(AreaToLineAxis1):
 
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        expand_aggs_and_cols = self.expand_aggs_and_cols(append)
+        draw_trapezoid_y = _build_draw_trapezoid_y(append, expand_aggs_and_cols)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         extend_area = _build_extend_area_to_line_axis1_x_constant(
-            draw_trapezoid_y, map_onto_pixel)
+            draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+        )
 
         x_values = self.x
         y_names = self.y
@@ -656,10 +674,12 @@ class AreaToZeroAxis1YConstant(AreaToZeroAxis1):
 
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        expand_aggs_and_cols = self.expand_aggs_and_cols(append)
+        draw_trapezoid_y = _build_draw_trapezoid_y(append, expand_aggs_and_cols)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         extend_area = _build_extend_area_to_zero_axis1_y_constant(
-            draw_trapezoid_y, map_onto_pixel)
+            draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+        )
 
         x_names = self.x
         y_values = self.y
@@ -707,10 +727,12 @@ class AreaToLineAxis1YConstant(AreaToLineAxis1):
 
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        expand_aggs_and_cols = self.expand_aggs_and_cols(append)
+        draw_trapezoid_y = _build_draw_trapezoid_y(append, expand_aggs_and_cols)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         extend_area = _build_extend_area_to_line_axis1_y_constant(
-            draw_trapezoid_y, map_onto_pixel)
+            draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+        )
         x_names = self.x
         y_values = self.y
         y_stack_values = self.y_stack
@@ -773,10 +795,12 @@ class AreaToZeroAxis1Ragged(_PointLike):
 
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        expand_aggs_and_cols = self.expand_aggs_and_cols(append)
+        draw_trapezoid_y = _build_draw_trapezoid_y(append, expand_aggs_and_cols)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         extend_area = _build_extend_area_to_zero_axis1_ragged(
-            draw_trapezoid_y, map_onto_pixel)
+            draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+        )
         x_name = self.x
         y_name = self.y
 
@@ -842,10 +866,12 @@ class AreaToLineAxis1Ragged(_AreaToLineLike):
 
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-        draw_trapezoid_y = _build_draw_trapezoid_y(append)
+        expand_aggs_and_cols = self.expand_aggs_and_cols(append)
+        draw_trapezoid_y = _build_draw_trapezoid_y(append, expand_aggs_and_cols)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
         extend_area = _build_extend_area_to_line_axis1_ragged(
-            draw_trapezoid_y, map_onto_pixel)
+            draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+        )
         x_name = self.x
         y_name = self.y
         y_stack_name = self.y_stack
@@ -861,7 +887,7 @@ class AreaToLineAxis1Ragged(_AreaToLineLike):
         return extend
 
 
-def _build_draw_trapezoid_y(append):
+def _build_draw_trapezoid_y(append, expand_aggs_and_cols):
     """Specialize a plotting kernel for drawing a trapezoid with two
     sides parallel to the y-axis"""
 
@@ -888,6 +914,7 @@ def _build_draw_trapezoid_y(append):
         return out_of_bounds, clamped_ystarti, clamped_ystopi
 
     @ngjit
+    @expand_aggs_and_cols
     def draw_trapezoid_y(x0i, x1i, y0i, y1i, y2i, y3i, xmaxi, ymaxi,
                          i, plot_start, clipped, stacked, *aggs_and_cols):
         """Draw a filled trapezoid that has two sides parallel to the y-axis
@@ -1139,8 +1166,11 @@ def _skip_or_clip_trapezoid_y(x0, x1, y0, y1, y2, y3, bounds, plot_start):
     return x0, x1, y0, y1, y2, y3, skip, clipped, plot_start
 
 
-def _build_extend_area_to_zero_axis0(draw_trapezoid_y, map_onto_pixel):
+def _build_extend_area_to_zero_axis0(
+        draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+):
     @ngjit
+    @expand_aggs_and_cols
     def extend_area(vt, bounds, xs, ys, plot_start, *aggs_and_cols):
         """Aggregate filled area along a line formed by
         ``xs`` and ``ys``, filled to the y=0 line"""
@@ -1150,6 +1180,7 @@ def _build_extend_area_to_zero_axis0(draw_trapezoid_y, map_onto_pixel):
 
         nrows = xs.shape[0]
         i = 0
+
         while i < nrows - 1:
             x0 = xs[i]
             x1 = xs[i + 1]
@@ -1178,8 +1209,11 @@ def _build_extend_area_to_zero_axis0(draw_trapezoid_y, map_onto_pixel):
     return extend_area
 
 
-def _build_extend_area_to_line_axis0(draw_trapezoid_y, map_onto_pixel):
+def _build_extend_area_to_line_axis0(
+        draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+):
     @ngjit
+    @expand_aggs_and_cols
     def extend_area(vt, bounds, xs, ys0, ys1, plot_start, *aggs_and_cols):
         """Aggregate filled area between the line formed by
         ``xs`` and ``ys0`` and the line formed by ``xs`` and ``ys1``"""
@@ -1217,8 +1251,11 @@ def _build_extend_area_to_line_axis0(draw_trapezoid_y, map_onto_pixel):
     return extend_area
 
 
-def _build_extend_area_to_zero_axis0_multi(draw_trapezoid_y, map_onto_pixel):
+def _build_extend_area_to_zero_axis0_multi(
+        draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+):
     @ngjit
+    @expand_aggs_and_cols
     def extend_area(vt, bounds, xs, ys, plot_start, *aggs_and_cols):
         """Aggregate filled area along a line formed by
         ``xs`` and ``ys``, filled to the y=0 line"""
@@ -1264,8 +1301,11 @@ def _build_extend_area_to_zero_axis0_multi(draw_trapezoid_y, map_onto_pixel):
     return extend_area
 
 
-def _build_extend_area_to_line_axis0_multi(draw_trapezoid_y, map_onto_pixel):
+def _build_extend_area_to_line_axis0_multi(
+        draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+):
     @ngjit
+    @expand_aggs_and_cols
     def extend_area(vt, bounds, xs, ys0, ys1, plot_start, *aggs_and_cols):
         """Aggregate filled area along a line formed by
         ``xs`` and ``ys``, filled to the y=0 line"""
@@ -1311,8 +1351,11 @@ def _build_extend_area_to_line_axis0_multi(draw_trapezoid_y, map_onto_pixel):
     return extend_area
 
 
-def _build_extend_area_to_zero_axis1_none_constant(draw_trapezoid_y, map_onto_pixel):
+def _build_extend_area_to_zero_axis1_none_constant(
+        draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+):
     @ngjit
+    @expand_aggs_and_cols
     def extend_area(vt, bounds, xs, ys, plot_start, *aggs_and_cols):
         """Aggregate filled area along a line formed by
         ``xs`` and ``ys``, filled to the y=0 line"""
@@ -1356,8 +1399,11 @@ def _build_extend_area_to_zero_axis1_none_constant(draw_trapezoid_y, map_onto_pi
     return extend_area
 
 
-def _build_extend_area_to_line_axis1_none_constant(draw_trapezoid_y, map_onto_pixel):
+def _build_extend_area_to_line_axis1_none_constant(
+        draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+):
     @ngjit
+    @expand_aggs_and_cols
     def extend_area(vt, bounds, xs, ys0, ys1, plot_start, *aggs_and_cols):
         """Aggregate filled area along a line formed by
         ``xs`` and ``ys``, filled to the y=0 line"""
@@ -1401,8 +1447,11 @@ def _build_extend_area_to_line_axis1_none_constant(draw_trapezoid_y, map_onto_pi
     return extend_area
 
 
-def _build_extend_area_to_zero_axis1_x_constant(draw_trapezoid_y, map_onto_pixel):
+def _build_extend_area_to_zero_axis1_x_constant(
+        draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+):
     @ngjit
+    @expand_aggs_and_cols
     def extend_area(vt, bounds, xs, ys, plot_start, *aggs_and_cols):
         """Aggregate filled area along a line formed by
         ``xs`` and ``ys``, filled to the y=0 line"""
@@ -1446,8 +1495,11 @@ def _build_extend_area_to_zero_axis1_x_constant(draw_trapezoid_y, map_onto_pixel
     return extend_area
 
 
-def _build_extend_area_to_line_axis1_x_constant(draw_trapezoid_y, map_onto_pixel):
+def _build_extend_area_to_line_axis1_x_constant(
+        draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+):
     @ngjit
+    @expand_aggs_and_cols
     def extend_area(vt, bounds, xs, ys0, ys1, plot_start, *aggs_and_cols):
         """Aggregate filled area along a line formed by
         ``xs`` and ``ys``, filled to the y=0 line"""
@@ -1491,8 +1543,11 @@ def _build_extend_area_to_line_axis1_x_constant(draw_trapezoid_y, map_onto_pixel
     return extend_area
 
 
-def _build_extend_area_to_zero_axis1_y_constant(draw_trapezoid_y, map_onto_pixel):
+def _build_extend_area_to_zero_axis1_y_constant(
+        draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+):
     @ngjit
+    @expand_aggs_and_cols
     def extend_area(vt, bounds, xs, ys, plot_start, *aggs_and_cols):
         """Aggregate filled area along a line formed by
         ``xs`` and ``ys``, filled to the y=0 line"""
@@ -1536,8 +1591,11 @@ def _build_extend_area_to_zero_axis1_y_constant(draw_trapezoid_y, map_onto_pixel
     return extend_area
 
 
-def _build_extend_area_to_line_axis1_y_constant(draw_trapezoid_y, map_onto_pixel):
+def _build_extend_area_to_line_axis1_y_constant(
+        draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+):
     @ngjit
+    @expand_aggs_and_cols
     def extend_area(vt, bounds, xs, ys0, ys1, plot_start, *aggs_and_cols):
         """Aggregate filled area along a line formed by
         ``xs`` and ``ys``, filled to the y=0 line"""
@@ -1581,7 +1639,9 @@ def _build_extend_area_to_line_axis1_y_constant(draw_trapezoid_y, map_onto_pixel
     return extend_area
 
 
-def _build_extend_area_to_zero_axis1_ragged(draw_trapezoid_y, map_onto_pixel):
+def _build_extend_area_to_zero_axis1_ragged(
+        draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+):
 
     def extend_line(vt, bounds, xs, ys, plot_start, *aggs_and_cols):
         x_start_indices = xs.start_indices
@@ -1595,6 +1655,7 @@ def _build_extend_area_to_zero_axis1_ragged(draw_trapezoid_y, map_onto_pixel):
             y_start_indices, y_flat_array, plot_start, *aggs_and_cols)
 
     @ngjit
+    @expand_aggs_and_cols
     def perform_extend_area_to_zero_axis1_ragged(
             vt, bounds, x_start_indices, x_flat_array,
             y_start_indices, y_flat_array, plot_start, *aggs_and_cols):
@@ -1659,7 +1720,9 @@ def _build_extend_area_to_zero_axis1_ragged(draw_trapezoid_y, map_onto_pixel):
     return extend_line
 
 
-def _build_extend_area_to_line_axis1_ragged(draw_trapezoid_y, map_onto_pixel):
+def _build_extend_area_to_line_axis1_ragged(
+        draw_trapezoid_y, map_onto_pixel, expand_aggs_and_cols
+):
 
     def extend_line(vt, bounds, xs, ys0, ys1, plot_start, *aggs_and_cols):
         x_start_indices = xs.start_indices
@@ -1677,6 +1740,7 @@ def _build_extend_area_to_line_axis1_ragged(draw_trapezoid_y, map_onto_pixel):
             plot_start, *aggs_and_cols)
 
     @ngjit
+    @expand_aggs_and_cols
     def perform_extend_area_to_line_axis1_ragged(
             vt, bounds, x_start_indices, x_flat_array,
             y0_start_indices, y0_flat_array, y1_start_indices, y1_flat_array,

--- a/datashader/glyphs/glyph.py
+++ b/datashader/glyphs/glyph.py
@@ -93,6 +93,14 @@ class Glyph(Expr):
 
     @staticmethod
     def _expand_aggs_and_cols(append, ndims):
+        if os.environ.get('NUMBA_DISABLE_JIT', None):
+            # If the NUMBA_DISABLE_JIT environment is set, then we return an
+            # identity decorator (one that return function unchanged).
+            #
+            # Doing this makes it possible to debug functions that are
+            # decorated with @jit and @expand_varargs decorators
+            return lambda fn: fn
+
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             try:

--- a/datashader/glyphs/glyph.py
+++ b/datashader/glyphs/glyph.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division
 import inspect
 import warnings
+import os
 import numpy as np
 
 from datashader.utils import Expr, ngjit
@@ -72,7 +73,11 @@ class Glyph(Expr):
 
         Rationale: When we know the fixed length of a variable length
         argument, replacing it with fixed arguments can help numba better
-        optimize the the function
+        optimize the the function.
+
+        If this ever causes problems in the future, this decorator can be
+        safely removed without changing the functionality of the decorated
+        function.
 
         Parameters
         ----------

--- a/datashader/glyphs/glyph.py
+++ b/datashader/glyphs/glyph.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division
 import inspect
+import warnings
 import numpy as np
 
 from datashader.utils import Expr, ngjit
@@ -87,12 +88,14 @@ class Glyph(Expr):
 
     @staticmethod
     def _expand_aggs_and_cols(append, ndims):
-        try:
-            # Numba keeps original function around as append.py_func
-            append_args = inspect.getfullargspec(append.py_func).args
-        except (TypeError, AttributeError):
-            # Treat append as a normal python function
-            append_args = inspect.getfullargspec(append).args
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            try:
+                # Numba keeps original function around as append.py_func
+                append_args = inspect.getargspec(append.py_func).args
+            except (TypeError, AttributeError):
+                # Treat append as a normal python function
+                append_args = inspect.getargspec(append).args
 
         # Get number of arguments accepted by append
         append_arglen = len(append_args)

--- a/datashader/glyphs/line.py
+++ b/datashader/glyphs/line.py
@@ -16,9 +16,12 @@ class LineAxis0(_PointLike):
     """
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-        draw_line = _build_draw_line(append)
+        expand_aggs_and_cols = self.expand_aggs_and_cols(append)
+        draw_line = _build_draw_line(append, expand_aggs_and_cols)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
-        extend_line = _build_extend_line_axis0(draw_line, map_onto_pixel)
+        extend_line = _build_extend_line_axis0(
+            draw_line, map_onto_pixel, expand_aggs_and_cols
+        )
         x_name = self.x
         y_name = self.y
 
@@ -83,9 +86,12 @@ class LineAxis0Multi(_PointLike):
 
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-        draw_line = _build_draw_line(append)
+        expand_aggs_and_cols = self.expand_aggs_and_cols(append)
+        draw_line = _build_draw_line(append, expand_aggs_and_cols)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
-        extend_line = _build_extend_line_axis0_multi(draw_line, map_onto_pixel)
+        extend_line = _build_extend_line_axis0_multi(
+            draw_line, map_onto_pixel, expand_aggs_and_cols
+        )
         x_names = self.x
         y_names = self.y
 
@@ -173,9 +179,12 @@ class LinesAxis1(_PointLike):
 
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-        draw_line = _build_draw_line(append)
+        expand_aggs_and_cols = self.expand_aggs_and_cols(append)
+        draw_line = _build_draw_line(append, expand_aggs_and_cols)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
-        extend_lines_xy = _build_extend_line_axis1_none_constant(draw_line, map_onto_pixel)
+        extend_lines_xy = _build_extend_line_axis1_none_constant(
+            draw_line, map_onto_pixel, expand_aggs_and_cols
+        )
         x_names = self.x
         y_names = self.y
 
@@ -225,9 +234,12 @@ class LinesAxis1XConstant(LinesAxis1):
 
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-        draw_line = _build_draw_line(append)
+        expand_aggs_and_cols = self.expand_aggs_and_cols(append)
+        draw_line = _build_draw_line(append, expand_aggs_and_cols)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
-        extend_lines = _build_extend_line_axis1_x_constant(draw_line, map_onto_pixel)
+        extend_lines = _build_extend_line_axis1_x_constant(
+            draw_line, map_onto_pixel, expand_aggs_and_cols
+        )
 
         x_values = self.x
         y_names = self.y
@@ -277,9 +289,12 @@ class LinesAxis1YConstant(LinesAxis1):
 
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-        draw_line = _build_draw_line(append)
+        expand_aggs_and_cols = self.expand_aggs_and_cols(append)
+        draw_line = _build_draw_line(append, expand_aggs_and_cols)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
-        extend_lines = _build_extend_line_axis1_y_constant(draw_line, map_onto_pixel)
+        extend_lines = _build_extend_line_axis1_y_constant(
+            draw_line, map_onto_pixel, expand_aggs_and_cols
+        )
 
         x_names = self.x
         y_values = self.y
@@ -335,9 +350,12 @@ class LinesAxis1Ragged(_PointLike):
 
     @memoize
     def _build_extend(self, x_mapper, y_mapper, info, append):
-        draw_line = _build_draw_line(append)
+        expand_aggs_and_cols = self.expand_aggs_and_cols(append)
+        draw_line = _build_draw_line(append, expand_aggs_and_cols)
         map_onto_pixel = _build_map_onto_pixel_for_line(x_mapper, y_mapper)
-        extend_lines_ragged = _build_extend_line_axis1_ragged(draw_line, map_onto_pixel)
+        extend_lines_ragged = _build_extend_line_axis1_ragged(
+            draw_line, map_onto_pixel, expand_aggs_and_cols
+        )
         x_name = self.x
         y_name = self.y
 
@@ -391,9 +409,10 @@ def _build_map_onto_pixel_for_line(x_mapper, y_mapper):
     return map_onto_pixel
 
 
-def _build_draw_line(append):
+def _build_draw_line(append, expand_aggs_and_cols):
     """Specialize a line plotting kernel for a given append/axis combination"""
     @ngjit
+    @expand_aggs_and_cols
     def draw_line(x0i, y0i, x1i, y1i, i, plot_start, clipped, *aggs_and_cols):
         """Draw a line using Bresenham's algorithm
 
@@ -526,8 +545,9 @@ def _skip_or_clip(x0, x1, y0, y1, bounds, plot_start):
     return x0, x1, y0, y1, skip, clipped, plot_start
 
 
-def _build_extend_line_axis0(draw_line, map_onto_pixel):
+def _build_extend_line_axis0(draw_line, map_onto_pixel, expand_aggs_and_cols):
     @ngjit
+    @expand_aggs_and_cols
     def extend_line(vt, bounds, xs, ys, plot_start, *aggs_and_cols):
         """Aggregate along a line formed by ``xs`` and ``ys``"""
         nrows = xs.shape[0]
@@ -551,8 +571,9 @@ def _build_extend_line_axis0(draw_line, map_onto_pixel):
     return extend_line
 
 
-def _build_extend_line_axis0_multi(draw_line, map_onto_pixel):
+def _build_extend_line_axis0_multi(draw_line, map_onto_pixel, expand_aggs_and_cols):
     @ngjit
+    @expand_aggs_and_cols
     def extend_line(vt, bounds, xs, ys, plot_start, *aggs_and_cols):
         """Aggregate along a line formed by ``xs`` and ``ys``"""
         nrows = xs[0].shape[0]
@@ -583,8 +604,11 @@ def _build_extend_line_axis0_multi(draw_line, map_onto_pixel):
     return extend_line
 
 
-def _build_extend_line_axis1_none_constant(draw_line, map_onto_pixel):
+def _build_extend_line_axis1_none_constant(
+        draw_line, map_onto_pixel, expand_aggs_and_cols
+):
     @ngjit
+    @expand_aggs_and_cols
     def extend_line(vt, bounds, xs, ys, plot_start, *aggs_and_cols):
         """
         here xs and ys are tuples of arrays and non-empty
@@ -617,8 +641,11 @@ def _build_extend_line_axis1_none_constant(draw_line, map_onto_pixel):
     return extend_line
 
 
-def _build_extend_line_axis1_x_constant(draw_line, map_onto_pixel):
+def _build_extend_line_axis1_x_constant(
+        draw_line, map_onto_pixel, expand_aggs_and_cols
+):
     @ngjit
+    @expand_aggs_and_cols
     def extend_line(vt, bounds, xs, ys, plot_start, *aggs_and_cols):
         """
         here xs and ys are tuples of arrays and non-empty
@@ -651,8 +678,11 @@ def _build_extend_line_axis1_x_constant(draw_line, map_onto_pixel):
     return extend_line
 
 
-def _build_extend_line_axis1_y_constant(draw_line, map_onto_pixel):
+def _build_extend_line_axis1_y_constant(
+        draw_line, map_onto_pixel, expand_aggs_and_cols
+):
     @ngjit
+    @expand_aggs_and_cols
     def extend_line(vt, bounds, xs, ys, plot_start, *aggs_and_cols):
         """
         here xs and ys are tuples of arrays and non-empty
@@ -685,7 +715,9 @@ def _build_extend_line_axis1_y_constant(draw_line, map_onto_pixel):
     return extend_line
 
 
-def _build_extend_line_axis1_ragged(draw_line, map_onto_pixel):
+def _build_extend_line_axis1_ragged(
+        draw_line, map_onto_pixel, expand_aggs_and_cols
+):
 
     def extend_line(vt, bounds, xs, ys, plot_start, *aggs_and_cols):
         x_start_indices = xs.start_indices
@@ -704,6 +736,7 @@ def _build_extend_line_axis1_ragged(draw_line, map_onto_pixel):
                                     *aggs_and_cols)
 
     @ngjit
+    @expand_aggs_and_cols
     def perform_extend_lines_ragged(vt,
                                     bounds,
                                     x_start_indices,

--- a/datashader/glyphs/points.py
+++ b/datashader/glyphs/points.py
@@ -80,6 +80,7 @@ class Point(_PointLike):
         y_name = self.y
 
         @ngjit
+        @self.expand_aggs_and_cols(append)
         def _extend(vt, bounds, xs, ys, *aggs_and_cols):
             sx, tx, sy, ty = vt
             xmin, xmax, ymin, ymax = bounds

--- a/datashader/macros.py
+++ b/datashader/macros.py
@@ -1,0 +1,263 @@
+import re
+import copy
+import inspect
+import ast
+import textwrap
+"""
+Utilities for manipulating the Abstract Syntax Tree of Python constructs 
+"""
+
+
+class NameVisitor(ast.NodeVisitor):
+    """
+    NodeVisitor that builds a set of all of the named identifiers in an AST
+    """
+    def __init__(self, *args, **kwargs):
+        super(NameVisitor, self).__init__(*args, **kwargs)
+        self.names = set()
+
+    def visit_Name(self, node):
+        self.names.add(node.id)
+
+    def visit_arg(self, node):
+        self.names.add(node.arg)
+
+    def get_new_names(self, num_names):
+        """
+        Returns a list of new names that are not already present in the AST.
+
+        New names will have the form _N, for N a non-negative integer. If the
+        AST has no existing identifiers of this form, then the returned names
+        will start at 0 ('_0', '_1', '_2'). If the AST already has identifiers
+        of this form, then the names returned will not include the existing
+        identifiers.
+
+        Parameters
+        ----------
+        num_names: int
+            The number of new names to return
+
+        Returns
+        -------
+        list of str
+        """
+        prop_re = re.compile(r"_(\d+)")
+        matching_names = [n for n in self.names if prop_re.fullmatch(n)]
+        if matching_names:
+            start_number = max([int(n[1:]) for n in matching_names]) + 1
+        else:
+            start_number = 0
+
+        return ["_" + str(n) for n in
+                range(start_number, start_number + num_names)]
+
+
+class ExpandVarargTransformer(ast.NodeTransformer):
+    """
+    Node transformer that replaces the starred use of a variable in an AST
+    with a collection of unstarred named variables.
+    """
+    def __init__(self, starred_name, expand_names, *args, **kwargs):
+        """
+        Parameters
+        ----------
+        starred_name: str
+            The name of the starred variable to replace
+        expand_names: list of stf
+            List of the new names that should be used to replace the starred
+            variable
+
+        """
+        super(ExpandVarargTransformer, self).__init__(*args, **kwargs)
+        self.starred_name = starred_name
+        self.expand_names = expand_names
+
+    def visit_Starred(self, node):
+        if node.value.id == self.starred_name:
+            return [ast.Name(id=name, ctx=node.ctx) for name in
+                    self.expand_names]
+        else:
+            return node
+
+
+def function_to_ast(fn):
+    """
+    Get the AST representation of a function
+    """
+    # Get source code for function
+    # Dedent is needed if this is a nested function
+    fn_source = textwrap.dedent(inspect.getsource(fn))
+
+    # Parse function source code into an AST
+    fn_ast = ast.parse(fn_source)
+
+    # # The function will be the fist element of the module body
+    # fn_ast = module_ast.body[0]
+
+    return fn_ast
+
+
+def ast_to_source(ast):
+    """Convert AST to source code string using the astor package"""
+    import astor
+    return astor.to_source(ast)
+
+
+def compile_function_ast(fn_ast):
+    """
+    Compile function AST into a code object suitable for use in eval/exec
+    """
+    assert isinstance(fn_ast, ast.Module)
+    fndef_ast = fn_ast.body[0]
+    assert isinstance(fndef_ast, ast.FunctionDef)
+    return compile(fn_ast, "<%s>" % fndef_ast.name, mode='exec')
+
+
+def function_ast_to_function(fn_ast, stacklevel=1):
+    # Validate
+    assert isinstance(fn_ast, ast.Module)
+    fndef_ast = fn_ast.body[0]
+    assert isinstance(fndef_ast, ast.FunctionDef)
+
+    # Compile AST to code object
+    code = compile_function_ast(fn_ast)
+
+    # Evaluate the function in a scope that includes the globals and
+    # locals of desired frame.
+    current_frame = inspect.currentframe()
+    eval_frame = current_frame
+    for _ in range(stacklevel):
+        eval_frame = eval_frame.f_back
+
+    eval_locals = eval_frame.f_locals
+    eval_globals = eval_frame.f_globals
+    del current_frame
+    scope = copy.copy(eval_globals)
+    scope.update(eval_locals)
+
+    # Evaluate function in scope
+    eval(code, scope)
+
+    # Return the newly evaluated function from the scope
+    return scope[fndef_ast.name]
+
+
+def expand_function_ast_varargs(fn_ast, expand_number):
+    """
+    Given a function AST that use a variable length positional argument
+    (e.g. *args), return a function that replaces the use of this argument
+    with one or more fixed arguments.
+
+    To be supported, a function must have a starred argument in the function
+    signature, and it may only use this argument in starred form as the
+    input to other functions.
+
+    For example, suppose expand_number is 3 and fn_ast is an AST
+    representing this function...
+
+    def my_fn1(a, b, *args):
+        print(a, b)
+        other_fn(a, b, *args)
+
+    Then this function will return the AST of a function equivalent to...
+
+    def my_fn1(a, b, _0, _1, _2):
+        print(a, b)
+        other_fn(a, b, _0, _1, _2)
+
+    If the input function uses `args` for anything other than passing it to
+    other functions in starred form, an error will be raised.
+
+    Parameters
+    ----------
+    fn_ast: ast.FunctionDef
+    expand_number: int
+
+    Returns
+    -------
+    ast.FunctionDef
+    """
+    assert isinstance(fn_ast, ast.Module)
+
+    # Copy ast so we don't modify the input
+    fn_ast = copy.deepcopy(fn_ast)
+
+    # Extract function definition
+    fndef_ast = fn_ast.body[0]
+    assert isinstance(fndef_ast, ast.FunctionDef)
+
+    # Get function args
+    fn_args = fndef_ast.args
+
+    # Function variabel arity argument
+    fn_vararg = fn_args.vararg
+
+    # Require vararg
+    if not fn_vararg:
+        raise ValueError("""\
+Input function AST does not have a variable length positional argument
+(e.g. *args) in the function signature""")
+    assert fn_vararg
+
+    # Get vararg name
+    vararg_name = fn_vararg.arg
+
+    # Compute new unique names to use in place of the variable argument
+    before_name_visitor = NameVisitor()
+    before_name_visitor.visit(fn_ast)
+    expand_names = before_name_visitor.get_new_names(expand_number)
+
+    # Replace vararg with additional args in function signature
+    fndef_ast.args.args.extend(
+        [ast.arg(arg=name, annotation=None) for name in expand_names]
+    )
+    fndef_ast.args.vararg = None
+
+    # Replace use of *args in function body
+    new_fn_ast = ExpandVarargTransformer(
+        vararg_name, expand_names
+    ).visit(fn_ast)
+
+    # Run a new NameVistor an see if there were any other non-starred uses
+    # of the variable length argument. If so, raise an exception
+    after_name_visitor = NameVisitor()
+    after_name_visitor.visit(new_fn_ast)
+    if vararg_name in after_name_visitor.names:
+        raise ValueError("""\
+The variable length positional argument {n} is used in an unsupported context
+""".format(n=vararg_name))
+
+    # Remove decorators if present to avoid recursion
+    fndef_ast.decorator_list = []
+
+    # Add missing source code locations
+    ast.fix_missing_locations(new_fn_ast)
+
+    # Return result
+    return new_fn_ast
+
+
+def expand_varargs(expand_number):
+    """
+    Decorator to expand the variable length (starred) argument in a function
+    signature with a fixed number of arguments.
+
+    Parameters
+    ----------
+    expand_number: int
+        The number of fixed arguments that should replace the variable length
+        argument
+
+    Returns
+    -------
+    function
+        Decorator Function
+    """
+    if not isinstance(expand_number, int) or expand_number < 0:
+        raise ValueError("expand_number must be a non-negative integer")
+
+    def _expand_varargs(fn):
+        fn_ast = function_to_ast(fn)
+        fn_expanded_ast = expand_function_ast_varargs(fn_ast, expand_number)
+        return function_ast_to_function(fn_expanded_ast, stacklevel=2)
+    return _expand_varargs

--- a/datashader/tests/benchmarks/test_draw_line.py
+++ b/datashader/tests/benchmarks/test_draw_line.py
@@ -4,8 +4,11 @@ import pytest
 
 import numpy as np
 
+from datashader.glyphs import Glyph
 from datashader.glyphs.line import _build_draw_line
 from datashader.utils import ngjit
+
+
 
 
 @pytest.fixture
@@ -14,7 +17,8 @@ def draw_line():
     def append(i, x, y, agg):
         agg[y, x] += 1
 
-    return _build_draw_line(append)
+    expand_aggs_and_cols = Glyph._expand_aggs_and_cols(append, 1)
+    return _build_draw_line(append, expand_aggs_and_cols)
 
 
 @pytest.mark.benchmark(group="draw_line")

--- a/datashader/tests/benchmarks/test_extend_line.py
+++ b/datashader/tests/benchmarks/test_extend_line.py
@@ -2,6 +2,7 @@ import pytest
 
 import numpy as np
 
+from datashader.glyphs import Glyph
 from datashader.glyphs.line import (
     _build_draw_line, _build_extend_line_axis0, _build_map_onto_pixel_for_line
 )
@@ -16,8 +17,11 @@ def extend_line():
 
     mapper = ngjit(lambda x: x)
     map_onto_pixel = _build_map_onto_pixel_for_line(mapper, mapper)
-    draw_line = _build_draw_line(append)
-    return _build_extend_line_axis0(draw_line, map_onto_pixel)
+    expand_aggs_and_cols = Glyph._expand_aggs_and_cols(append, 1)
+    draw_line = _build_draw_line(append, expand_aggs_and_cols)
+    return _build_extend_line_axis0(
+        draw_line, map_onto_pixel, expand_aggs_and_cols
+    )
 
 
 @pytest.mark.parametrize('high', [0, 10**5])

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -3,7 +3,7 @@ import pandas as pd
 import numpy as np
 import pytest
 
-from datashader.glyphs import Point, LinesAxis1
+from datashader.glyphs import Point, LinesAxis1, Glyph
 
 from datashader.glyphs.area import _build_draw_trapezoid_y
 from datashader.glyphs.line import (
@@ -51,15 +51,18 @@ map_onto_pixel_for_line = _build_map_onto_pixel_for_line(mapper, mapper)
 map_onto_pixel_for_triangle = _build_map_onto_pixel_for_triangle(mapper, mapper)
 
 # Line rasterization
-draw_line = _build_draw_line(append)
-extend_line = _build_extend_line_axis0(draw_line, map_onto_pixel_for_line)
+expand_aggs_and_cols = Glyph._expand_aggs_and_cols(append, 1)
+draw_line = _build_draw_line(append, expand_aggs_and_cols)
+extend_line = _build_extend_line_axis0(
+    draw_line, map_onto_pixel_for_line, expand_aggs_and_cols
+)
 
 # Triangles rasterization
 draw_triangle, draw_triangle_interp = _build_draw_triangle(tri_append)
 extend_triangles = _build_extend_triangles(draw_triangle, draw_triangle_interp, map_onto_pixel_for_triangle)
 
 # Trapezoid y rasterization
-draw_trapezoid = _build_draw_trapezoid_y(append)
+draw_trapezoid = _build_draw_trapezoid_y(append, expand_aggs_and_cols)
 
 bounds = (-3, 1, -3, 1)
 vt = (1., 3., 1., 3.)

--- a/datashader/tests/test_macros.py
+++ b/datashader/tests/test_macros.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+import warnings
 import pytest
 
 from datashader.macros import expand_varargs
@@ -30,7 +32,10 @@ def function_with_vararg_call_numba(a, b, *others):
 
 # Help functions
 def get_args(fn):
-    spec = inspect.getfullargspec(fn)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        spec = inspect.getargspec(fn)
+
     args = spec.args
     if spec.varargs:
         args += ['*' + spec.varargs]

--- a/datashader/tests/test_macros.py
+++ b/datashader/tests/test_macros.py
@@ -1,0 +1,77 @@
+import pytest
+
+from datashader.macros import expand_varargs
+import inspect
+from numba import jit
+
+
+# Example functions to test expand_varargs on
+def function_no_vararg(a, b):
+    return a + b
+
+
+def function_with_vararg(a, b, *others):
+    return a + b - function_no_vararg(*others)
+
+
+def function_with_unsupported_vararg_use(a, b, *others):
+    print(others[0])
+    function_with_vararg(a, b, *others)
+
+
+@jit(nopython=True, nogil=True)
+def function_no_vararg_numba(a, b):
+    return a + b
+
+
+def function_with_vararg_call_numba(a, b, *others):
+    return a + b - function_no_vararg_numba(*others)
+
+
+# Help functions
+def get_args(fn):
+    spec = inspect.getfullargspec(fn)
+    args = spec.args
+    if spec.varargs:
+        args += ['*' + spec.varargs]
+
+    return args
+
+
+# Tests
+def test_expand_varargs():
+    assert get_args(function_with_vararg) == ['a', 'b', '*others']
+    function_with_vararg_expanded = expand_varargs(2)(function_with_vararg)
+    assert get_args(function_with_vararg_expanded) == ['a', 'b', '_0', '_1']
+
+    assert (function_with_vararg(1, 2, 3, 4) ==
+            function_with_vararg_expanded(1, 2, 3, 4))
+
+
+def test_invalid_expand_number():
+    with pytest.raises(ValueError) as e:
+        # User forgets to construct decorator with expand_number
+        expand_varargs(function_no_vararg)
+
+    assert e.match(r"non\-negative integer")
+
+
+def test_no_varargs_error():
+    with pytest.raises(ValueError) as e:
+        expand_varargs(2)(function_no_vararg)
+
+    assert e.match(r"does not have a variable length positional argument")
+
+
+def test_unsupported_vararg_use():
+    with pytest.raises(ValueError) as e:
+        expand_varargs(2)(function_with_unsupported_vararg_use)
+
+    assert e.match(r"unsupported context")
+
+
+def test_numba_jit_expanded_function():
+    jit_fn = jit(nopython=True, nogil=True)(
+        expand_varargs(2)(function_with_vararg_call_numba)
+    )
+    assert function_with_vararg_call_numba(1, 2, 3, 4) == jit_fn(1, 2, 3, 4)


### PR DESCRIPTION
## Background
This PR is motivated by the performance characteristics discovered while developing the quadmesh glyph in https://github.com/pyviz/datashader/pull/779. In particular, see the discussion of fixed vs variable length arguments in https://github.com/pyviz/datashader/pull/779#issuecomment-521248206.

The key insight here is that during glyph rendering, the numba optimization of the rendering functions can result in substantially faster code if the input functions contain a fixed number of arguments rather than a variable length argument (e.g. *args).

In the glyph rendering code, this variable length argument is usually called `*aggs_and_cols` and it contains a list of the aggregate arrays that are being populated and the columns that are used as input to the reduction calculations.  The length of this argument varies depending on the chosen reduction operation, but the length will remain the same for every render call for a given operation.

## Implementation
### expand_varargs
This PR adds a `datashader.macros` module that provides the `expand_varargs` decorator builder.  This decorator builder inputs the desired number of arguments to expand to, and returns a function decorator.  This function decorator will transform the [AST](https://docs.python.org/3/library/ast.html) of the wrapped function to replace variable length arguments with a fixed number of arguments/variables.

This only makes sense for cases where the only thing the function does with the variable length argument is to pass it along to other functions in star-form.  For example, calling...

```python
@expand_varargs(2)
def example_fn(a, b, *args):
    print(a, b)
    other_fn(a, b, *args)
```

would transform the function AST into a function equivalent to 
```python
def example_fn(a, b, _0, _1):
    print(a, b)
    other_fn(a, b, _0, _1)
```

If the variable length argument is used in any other context then an error is raised. For example, an error will be raised if the `example_fn` looks inside `args`.

```python
@expand_varargs(2)
def example_fn(a, b, *args):
    print(a, b, args[0])
    other_fn(a, b, *args)
```
:arrow_up: would raise a `ValueError`.

The whole point of doing this is to transform the input function before it is passed to numba's jit compilation decorator.

### Glyph.expand_aggs_and_cols
A new `expand_aggs_and_cols` method has been added to the `Glyph` baseclass. This method inputs the `append` function that will perform the reduction operation, and returns an `expand_varargs` decorator configured to expand the `*aggs_and_cols` argument to the correct number of fixed arguments.

### Glyph updates
The new decorator has been added to all applicable rendering functions in the `points`, `line`, and `area` glyphs.  I think Trimesh could also benefit from this technique, but it doesn't quite follow the same pattern of passing around the `*aggs_and_cols` argument, so that will take some refactoring.  `raster` doesn't currently use the same glyph/aggregation framework.

## Performance results
Here are some benchmark comparisons of this branch with `master`.

Notebooks:
 - **Before**: https://anaconda.org/jonmmease/expand_varargs_before/notebook
 - **After**: https://anaconda.org/jonmmease/expand_varargs_after/notebook

I tested `points`, `line`, and `area` glyphs using the `count`, `sum`, `mean`, and `std` reduction operations.  Here is a plot of the results: 

![newplot](https://user-images.githubusercontent.com/15064365/63096998-531f9600-bf3d-11e9-8df0-dabbe4609910.png)

Note that the y-axis is time in seconds.

Notice how the improvements grow more significant as the reduction operation get more complex. This corresponds to the `*aggs_and_cols` argument getting longer.

The speedups for the coming quadmesh glyph should be even more significant than the gains for the area glyph above.

@jbednar @philippjfr 