### PR TITLE
Initial GPU support

### DIFF
--- a/datashader/data_libraries/__init__.py
+++ b/datashader/data_libraries/__init__.py
@@ -5,3 +5,14 @@ try:
     from . import dask    # noqa (API import)
 except ImportError:
     pass
+
+try:
+    import cudf as _cudf  # noqa (Test cudf installed)
+    import cupy as _cupy  # noqa (Test cupy installed)
+    from . import cudf    # noqa (API import)
+
+    import dask_cudf as _dask_cudf  # noqa (Test dask_cudf installed)
+    from . import dask_cudf         # noqa (API import)
+
+except ImportError:
+    pass

--- a/datashader/data_libraries/cudf.py
+++ b/datashader/data_libraries/cudf.py
@@ -1,0 +1,9 @@
+from __future__ import absolute_import
+from datashader.data_libraries.pandas import default
+from datashader.core import bypixel
+import cudf
+
+
+@bypixel.pipeline.register(cudf.DataFrame)
+def cudf_pipeline(df, schema, canvas, glyph, summary):
+    return default(glyph, df, schema, canvas, summary, cuda=True)

--- a/datashader/data_libraries/dask_cudf.py
+++ b/datashader/data_libraries/dask_cudf.py
@@ -1,0 +1,9 @@
+from __future__ import absolute_import
+from datashader.data_libraries.dask import dask_pipeline
+from datashader.core import bypixel
+import dask_cudf
+
+
+@bypixel.pipeline.register(dask_cudf.DataFrame)
+def dask_cudf_pipeline(df, schema, canvas, glyph, summary):
+    return dask_pipeline(df, schema, canvas, glyph, summary, cuda=True)

--- a/datashader/data_libraries/pandas.py
+++ b/datashader/data_libraries/pandas.py
@@ -22,8 +22,8 @@ glyph_dispatch = Dispatcher()
 
 @glyph_dispatch.register(_PointLike)
 @glyph_dispatch.register(_AreaToLineLike)
-def default(glyph, source, schema, canvas, summary):
-    create, info, append, _, finalize = compile_components(summary, schema, glyph)
+def default(glyph, source, schema, canvas, summary, cuda=False):
+    create, info, append, _, finalize = compile_components(summary, schema, glyph, cuda)
     x_mapper = canvas.x_axis.mapper
     y_mapper = canvas.y_axis.mapper
     extend = glyph._build_extend(x_mapper, y_mapper, info, append)
@@ -44,6 +44,7 @@ def default(glyph, source, schema, canvas, summary):
     extend(bases, source, x_st + y_st, x_range + y_range)
 
     return finalize(bases,
+                    cuda=cuda,
                     coords=OrderedDict([(glyph.x_label, x_axis),
                                         (glyph.y_label, y_axis)]),
                     dims=[glyph.y_label, glyph.x_label])

--- a/datashader/tests/benchmarks/test_extend_line.py
+++ b/datashader/tests/benchmarks/test_extend_line.py
@@ -19,7 +19,7 @@ def extend_line():
     map_onto_pixel = _build_map_onto_pixel_for_line(mapper, mapper)
     expand_aggs_and_cols = Glyph._expand_aggs_and_cols(append, 1)
     draw_line = _build_draw_segment(append, map_onto_pixel, expand_aggs_and_cols)
-    return _build_extend_line_axis0(draw_line, expand_aggs_and_cols)
+    return _build_extend_line_axis0(draw_line, expand_aggs_and_cols)[0]
 
 
 @pytest.mark.parametrize('high', [0, 10**5])

--- a/datashader/tests/test_dask.py
+++ b/datashader/tests/test_dask.py
@@ -10,23 +10,52 @@ import datashader.utils as du
 
 import pytest
 
+from datashader.tests.test_pandas import (
+    assert_eq_xr, assert_eq_ndarray, values
+)
+
 config.set(scheduler='synchronous')
 
-df = pd.DataFrame({'x': np.array(([0.] * 10 + [1] * 10)),
-                   'y': np.array(([0.] * 5 + [1] * 5 + [0] * 5 + [1] * 5)),
-                   'log_x': np.array(([1.] * 10 + [10] * 10)),
-                   'log_y': np.array(([1.] * 5 + [10] * 5 + [1] * 5 + [10] * 5)),
-                   'i32': np.arange(20, dtype='i4'),
-                   'i64': np.arange(20, dtype='i8'),
-                   'f32': np.arange(20, dtype='f4'),
-                   'f64': np.arange(20, dtype='f8'),
-                   'empty_bin': np.array([0.] * 15 + [np.nan] * 5),
-                   'cat': ['a']*5 + ['b']*5 + ['c']*5 + ['d']*5})
-df.cat = df.cat.astype('category')
-df.f32[2] = np.nan
-df.f64[2] = np.nan
+df_pd = pd.DataFrame({'x': np.array(([0.] * 10 + [1] * 10)),
+                      'y': np.array(([0.] * 5 + [1] * 5 + [0] * 5 + [1] * 5)),
+                      'log_x': np.array(([1.] * 10 + [10] * 10)),
+                      'log_y': np.array(([1.] * 5 + [10] * 5 + [1] * 5 + [10] * 5)),
+                      'i32': np.arange(20, dtype='i4'),
+                      'i64': np.arange(20, dtype='i8'),
+                      'f32': np.arange(20, dtype='f4'),
+                      'f64': np.arange(20, dtype='f8'),
+                      'empty_bin': np.array([0.] * 15 + [np.nan] * 5),
+                      'cat': ['a']*5 + ['b']*5 + ['c']*5 + ['d']*5})
+df_pd.cat = df_pd.cat.astype('category')
+df_pd.f32[2] = np.nan
+df_pd.f64[2] = np.nan
 
-ddf = dd.from_pandas(df, npartitions=3)
+_ddf = dd.from_pandas(df_pd, npartitions=2)
+
+
+def dask_DataFrame(*args, **kwargs):
+    return dd.from_pandas(pd.DataFrame(*args, **kwargs), npartitions=2)
+
+
+try:
+    import cudf
+    import cupy
+    import dask_cudf
+    ddfs = [_ddf, dask_cudf.from_dask_dataframe(_ddf)]
+
+    def dask_cudf_DataFrame(*args, **kwargs):
+        cdf = cudf.DataFrame.from_pandas(
+            pd.DataFrame(*args, **kwargs), nan_as_null=False
+        )
+        return dask_cudf.from_cudf(cdf, npartitions=2)
+
+    DataFrames = [dask_DataFrame, dask_cudf_DataFrame]
+except ImportError:
+    cudf = cupy = dask_cudf = None
+    ddfs = [_ddf]
+    DataFrames = [dask_DataFrame]
+    dask_cudf_DataFrame = None
+
 
 c = ds.Canvas(plot_width=2, plot_height=2, x_range=(0, 1), y_range=(0, 1))
 c_logx = ds.Canvas(plot_width=2, plot_height=2, x_range=(1, 10),
@@ -53,103 +82,134 @@ def floats(n):
         n = n + np.spacing(n)
 
 
-def test_count():
+@pytest.mark.parametrize('ddf', ddfs)
+def test_count(ddf):
     out = xr.DataArray(np.array([[5, 5], [5, 5]], dtype='i4'),
                        coords=coords, dims=dims)
-    assert_eq(c.points(ddf, 'x', 'y', ds.count('i32')), out)
-    assert_eq(c.points(ddf, 'x', 'y', ds.count('i64')), out)
-    assert_eq(c.points(ddf, 'x', 'y', ds.count()), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.count('i32')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.count('i64')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.count()), out)
     out = xr.DataArray(np.array([[4, 5], [5, 5]], dtype='i4'),
                        coords=coords, dims=dims)
-    assert_eq(c.points(ddf, 'x', 'y', ds.count('f32')), out)
-    assert_eq(c.points(ddf, 'x', 'y', ds.count('f64')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.count('f32')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.count('f64')), out)
 
 
-def test_any():
+@pytest.mark.parametrize('ddf', ddfs)
+def test_any(ddf):
     out = xr.DataArray(np.array([[True, True], [True, True]]),
                        coords=coords, dims=dims)
-    assert_eq(c.points(ddf, 'x', 'y', ds.any('i64')), out)
-    assert_eq(c.points(ddf, 'x', 'y', ds.any('f64')), out)
-    assert_eq(c.points(ddf, 'x', 'y', ds.any()), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.any('i64')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.any('f64')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.any()), out)
     out = xr.DataArray(np.array([[True, True], [True, False]]),
                        coords=coords, dims=dims)
-    assert_eq(c.points(ddf, 'x', 'y', ds.any('empty_bin')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.any('empty_bin')), out)
 
 
-def test_sum():
-    out = xr.DataArray(df.i32.values.reshape((2, 2, 5)).sum(axis=2, dtype='f8').T,
-                       coords=coords, dims=dims)
-    assert_eq(c.points(ddf, 'x', 'y', ds.sum('i32')), out)
-    assert_eq(c.points(ddf, 'x', 'y', ds.sum('i64')), out)
-    out = xr.DataArray(np.nansum(df.f64.values.reshape((2, 2, 5)), axis=2).T,
-                       coords=coords, dims=dims)
-    assert_eq(c.points(ddf, 'x', 'y', ds.sum('f32')), out)
-    assert_eq(c.points(ddf, 'x', 'y', ds.sum('f64')), out)
+@pytest.mark.parametrize('ddf', ddfs)
+def test_sum(ddf):
+    out = xr.DataArray(
+        values(df_pd.i32).reshape((2, 2, 5)).sum(axis=2, dtype='f8').T,
+        coords=coords, dims=dims)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.sum('i32')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.sum('i64')), out)
+
+    out = xr.DataArray(
+        np.nansum(values(df_pd.f64).reshape((2, 2, 5)), axis=2).T,
+        coords=coords, dims=dims)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.sum('f32')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.sum('f64')), out)
 
 
-def test_min():
-    out = xr.DataArray(df.i64.values.reshape((2, 2, 5)).min(axis=2).astype('f8').T,
-                       coords=coords, dims=dims)
-    assert_eq(c.points(ddf, 'x', 'y', ds.min('i32')), out)
-    assert_eq(c.points(ddf, 'x', 'y', ds.min('i64')), out)
-    assert_eq(c.points(ddf, 'x', 'y', ds.min('f32')), out)
-    assert_eq(c.points(ddf, 'x', 'y', ds.min('f64')), out)
+@pytest.mark.parametrize('ddf', ddfs)
+def test_min(ddf):
+    out = xr.DataArray(
+        values(df_pd.i64).reshape((2, 2, 5)).min(axis=2).astype('f8').T,
+        coords=coords, dims=dims)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.min('i32')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.min('i64')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.min('f32')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.min('f64')), out)
 
 
-def test_max():
-    out = xr.DataArray(df.i64.values.reshape((2, 2, 5)).max(axis=2).astype('f8').T,
-                       coords=coords, dims=dims)
-    assert_eq(c.points(ddf, 'x', 'y', ds.max('i32')), out)
-    assert_eq(c.points(ddf, 'x', 'y', ds.max('i64')), out)
-    assert_eq(c.points(ddf, 'x', 'y', ds.max('f32')), out)
-    assert_eq(c.points(ddf, 'x', 'y', ds.max('f64')), out)
+@pytest.mark.parametrize('ddf', ddfs)
+def test_max(ddf):
+    out = xr.DataArray(
+        values(df_pd.i64).reshape((2, 2, 5)).max(axis=2).astype('f8').T,
+        coords=coords, dims=dims)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.max('i32')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.max('i64')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.max('f32')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.max('f64')), out)
 
 
-def test_mean():
-    out = xr.DataArray(df.i32.values.reshape((2, 2, 5)).mean(axis=2, dtype='f8').T,
-                       coords=coords, dims=dims)
-    assert_eq(c.points(ddf, 'x', 'y', ds.mean('i32')), out)
-    assert_eq(c.points(ddf, 'x', 'y', ds.mean('i64')), out)
-    out = xr.DataArray(np.nanmean(df.f64.values.reshape((2, 2, 5)), axis=2).T,
-                       coords=coords, dims=dims)
-    assert_eq(c.points(ddf, 'x', 'y', ds.mean('f32')), out)
-    assert_eq(c.points(ddf, 'x', 'y', ds.mean('f64')), out)
+@pytest.mark.parametrize('ddf', ddfs)
+def test_mean(ddf):
+    out = xr.DataArray(
+        values(df_pd.i32).reshape((2, 2, 5)).mean(axis=2, dtype='f8').T,
+        coords=coords, dims=dims)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.mean('i32')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.mean('i64')), out)
+    out = xr.DataArray(
+        np.nanmean(values(df_pd.f64).reshape((2, 2, 5)), axis=2).T,
+        coords=coords, dims=dims)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.mean('f32')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.mean('f64')), out)
 
 
-def test_var():
-    out = xr.DataArray(df.i32.values.reshape((2, 2, 5)).var(axis=2, dtype='f8').T,
-                       coords=coords, dims=dims)
-    assert_eq(c.points(ddf, 'x', 'y', ds.var('i32')), out)
-    assert_eq(c.points(ddf, 'x', 'y', ds.var('i64')), out)
-    out = xr.DataArray(np.nanvar(df.f64.values.reshape((2, 2, 5)), axis=2).T,
-                       coords=coords, dims=dims)
-    assert_eq(c.points(ddf, 'x', 'y', ds.var('f32')), out)
-    assert_eq(c.points(ddf, 'x', 'y', ds.var('f64')), out)
+@pytest.mark.parametrize('ddf', ddfs)
+def test_var(ddf):
+    if dask_cudf and isinstance(ddf, dask_cudf.DataFrame):
+        pytest.skip("var not supported with cudf")
+
+    out = xr.DataArray(
+        values(df_pd.i32).reshape((2, 2, 5)).var(axis=2, dtype='f8').T,
+        coords=coords, dims=dims)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.var('i32')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.var('i64')), out)
+    out = xr.DataArray(
+        np.nanvar(values(df_pd.f64).reshape((2, 2, 5)), axis=2).T,
+        coords=coords, dims=dims)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.var('f32')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.var('f64')), out)
 
 
-def test_std():
-    out = xr.DataArray(df.i32.values.reshape((2, 2, 5)).std(axis=2, dtype='f8').T,
-                       coords=coords, dims=dims)
-    assert_eq(c.points(ddf, 'x', 'y', ds.std('i32')), out)
-    assert_eq(c.points(ddf, 'x', 'y', ds.std('i64')), out)
-    out = xr.DataArray(np.nanstd(df.f64.values.reshape((2, 2, 5)), axis=2).T,
-                       coords=coords, dims=dims)
-    assert_eq(c.points(ddf, 'x', 'y', ds.std('f32')), out)
-    assert_eq(c.points(ddf, 'x', 'y', ds.std('f64')), out)
+@pytest.mark.parametrize('ddf', ddfs)
+def test_std(ddf):
+    if dask_cudf and isinstance(ddf, dask_cudf.DataFrame):
+        pytest.skip("std not supported with cudf")
+
+    out = xr.DataArray(
+        values(df_pd.i32).reshape((2, 2, 5)).std(axis=2, dtype='f8').T,
+        coords=coords, dims=dims)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.std('i32')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.std('i64')), out)
+    out = xr.DataArray(
+        np.nanstd(values(df_pd.f64).reshape((2, 2, 5)), axis=2).T,
+        coords=coords, dims=dims)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.std('f32')), out)
+    assert_eq_xr(c.points(ddf, 'x', 'y', ds.std('f64')), out)
 
 
-def test_count_cat():
+@pytest.mark.parametrize('ddf', ddfs)
+def test_count_cat(ddf):
     sol = np.array([[[5, 0, 0, 0],
                      [0, 0, 5, 0]],
                     [[0, 5, 0, 0],
                      [0, 0, 0, 5]]])
-    out = xr.DataArray(sol, coords=(coords + [['a', 'b', 'c', 'd']]),
-                       dims=(dims + ['cat']))
+    out = xr.DataArray(
+        sol, coords=(coords + [['a', 'b', 'c', 'd']]), dims=(dims + ['cat'])
+    )
     agg = c.points(ddf, 'x', 'y', ds.count_cat('cat'))
-    assert_eq(agg, out)
+    assert_eq_xr(agg, out)
 
 
-def test_multiple_aggregates():
+@pytest.mark.parametrize('ddf', ddfs)
+def test_multiple_aggregates(ddf):
+    if dask_cudf and isinstance(ddf, dask_cudf.DataFrame):
+        pytest.skip("std not supported with cudf")
+
     agg = c.points(ddf, 'x', 'y',
                    ds.summary(f64_std=ds.std('f64'),
                               f64_mean=ds.mean('f64'),
@@ -157,39 +217,39 @@ def test_multiple_aggregates():
                               i32_count=ds.count('i32')))
 
     f = lambda x: xr.DataArray(x, coords=coords, dims=dims)
-    assert_eq(agg.f64_std, f(np.nanstd(df.f64.values.reshape((2, 2, 5)), axis=2).T))
-    assert_eq(agg.f64_mean, f(np.nanmean(df.f64.values.reshape((2, 2, 5)), axis=2).T))
-    assert_eq(agg.i32_sum, f(df.i32.values.reshape((2, 2, 5)).sum(axis=2, dtype='f8').T))
-    assert_eq(agg.i32_count, f(np.array([[5, 5], [5, 5]], dtype='i4')))
+    assert_eq_xr(agg.f64_std, f(np.nanstd(values(df_pd.f64).reshape((2, 2, 5)), axis=2).T))
+    assert_eq_xr(agg.f64_mean, f(np.nanmean(values(df_pd.f64).reshape((2, 2, 5)), axis=2).T))
+    assert_eq_xr(agg.i32_sum, f(values(df_pd.i32).reshape((2, 2, 5)).sum(axis=2, dtype='f8').T))
+    assert_eq_xr(agg.i32_count, f(np.array([[5, 5], [5, 5]], dtype='i4')))
 
 
-def test_auto_range_points():
+@pytest.mark.parametrize('DataFrame', DataFrames)
+def test_auto_range_points(DataFrame):
     n = 10
     data = np.arange(n, dtype='i4')
-    df = pd.DataFrame({'time': np.arange(n),
-                       'x': data,
-                       'y': data})
-    ddf = dd.from_pandas(df, npartitions=2)
+
+    ddf = DataFrame({'time': np.arange(n),
+                     'x': data,
+                     'y': data})
 
     cvs = ds.Canvas(plot_width=n, plot_height=n)
     agg = cvs.points(ddf, 'x', 'y', ds.count('time'))
     sol = np.zeros((n, n), int)
     np.fill_diagonal(sol, 1)
-    np.testing.assert_equal(agg.data, sol)
+    assert_eq_ndarray(agg.data, sol)
 
     cvs = ds.Canvas(plot_width=n+1, plot_height=n+1)
     agg = cvs.points(ddf, 'x', 'y', ds.count('time'))
     sol = np.zeros((n+1, n+1), int)
     np.fill_diagonal(sol, 1)
     sol[5, 5] = 0
-    np.testing.assert_equal(agg.data, sol)
+    assert_eq_ndarray(agg.data, sol)
 
     n = 4
     data = np.arange(n, dtype='i4')
-    df = pd.DataFrame({'time': np.arange(n),
-                       'x': data,
-                       'y': data})
-    ddf = dd.from_pandas(df, npartitions=2)
+    ddf = DataFrame({'time': np.arange(n),
+                     'x': data,
+                     'y': data})
 
     cvs = ds.Canvas(plot_width=2*n, plot_height=2*n)
     agg = cvs.points(ddf, 'x', 'y', ds.count('time'))
@@ -197,7 +257,7 @@ def test_auto_range_points():
     np.fill_diagonal(sol, 1)
     sol[[tuple(range(1, 4, 2))]] = 0
     sol[[tuple(range(4, 8, 2))]] = 0
-    np.testing.assert_equal(agg.data, sol)
+    assert_eq_ndarray(agg.data, sol)
 
     cvs = ds.Canvas(plot_width=2*n+1, plot_height=2*n+1)
     agg = cvs.points(ddf, 'x', 'y', ds.count('time'))
@@ -206,44 +266,47 @@ def test_auto_range_points():
     sol[3, 3] = 1
     sol[6, 6] = 1
     sol[8, 8] = 1
-    np.testing.assert_equal(agg.data, sol)
+    assert_eq_ndarray(agg.data, sol)
 
 
-def test_uniform_points():
+@pytest.mark.parametrize('DataFrame', DataFrames)
+def test_uniform_points(DataFrame):
     n = 101
-    df = pd.DataFrame({'time': np.ones(2*n, dtype='i4'),
-                       'x': np.concatenate((np.arange(n, dtype='f8'),
-                                            np.arange(n, dtype='f8'))),
-                       'y': np.concatenate(([0.] * n, [1.] * n))})
+    ddf = DataFrame({'time': np.ones(2*n, dtype='i4'),
+                     'x': np.concatenate((np.arange(n, dtype='f8'),
+                                          np.arange(n, dtype='f8'))),
+                     'y': np.concatenate(([0.] * n, [1.] * n))})
 
     cvs = ds.Canvas(plot_width=10, plot_height=2, y_range=(0, 1))
-    agg = cvs.points(df, 'x', 'y', ds.count('time'))
+    agg = cvs.points(ddf, 'x', 'y', ds.count('time'))
     sol = np.array([[10] * 9 + [11], [10] * 9 + [11]], dtype='i4')
-    np.testing.assert_equal(agg.data, sol)
+    assert_eq_ndarray(agg.data, sol)
 
 
+@pytest.mark.parametrize('DataFrame', DataFrames)
 @pytest.mark.parametrize('high', [9, 10, 99, 100])
 @pytest.mark.parametrize('low', [0])
-def test_uniform_diagonal_points(low, high):
+def test_uniform_diagonal_points(DataFrame, low, high):
     bounds = (low, high)
     x_range, y_range = bounds, bounds
 
     width = x_range[1] - x_range[0]
     height = y_range[1] - y_range[0]
     n = width * height
-    df = pd.DataFrame({'time': np.ones(n, dtype='i4'),
-                       'x': np.array([np.arange(*x_range, dtype='f8')] * width).flatten(),
-                       'y': np.array([np.arange(*y_range, dtype='f8')] * height).flatten()})
+    ddf = DataFrame({'time': np.ones(n, dtype='i4'),
+                     'x': np.array([np.arange(*x_range, dtype='f8')] * width).flatten(),
+                     'y': np.array([np.arange(*y_range, dtype='f8')] * height).flatten()})
 
     cvs = ds.Canvas(plot_width=2, plot_height=2, x_range=x_range, y_range=y_range)
-    agg = cvs.points(df, 'x', 'y', ds.count('time'))
+    agg = cvs.points(ddf, 'x', 'y', ds.count('time'))
 
     diagonal = agg.data.diagonal(0)
     assert sum(diagonal) == n
     assert abs(bounds[1] - bounds[0]) % 2 == abs(diagonal[1] / high - diagonal[0] / high)
 
 
-def test_log_axis_points():
+@pytest.mark.parametrize('ddf', ddfs)
+def test_log_axis_points(ddf):
     axis = ds.core.LogAxis()
     logcoords = axis.compute_index(axis.compute_scale_and_translate((1, 10), 2), 2)
 
@@ -253,22 +316,22 @@ def test_log_axis_points():
     sol = np.array([[5, 5], [5, 5]], dtype='i4')
     out = xr.DataArray(sol, coords=[lincoords, logcoords],
                        dims=['y', 'log_x'])
-    assert_eq(c_logx.points(ddf, 'log_x', 'y', ds.count('i32')), out)
+    assert_eq_xr(c_logx.points(ddf, 'log_x', 'y', ds.count('i32')), out)
     out = xr.DataArray(sol, coords=[logcoords, lincoords],
                        dims=['log_y', 'x'])
-    assert_eq(c_logy.points(ddf, 'x', 'log_y', ds.count('i32')), out)
+    assert_eq_xr(c_logy.points(ddf, 'x', 'log_y', ds.count('i32')), out)
     out = xr.DataArray(sol, coords=[logcoords, logcoords],
                        dims=['log_y', 'log_x'])
-    assert_eq(c_logxy.points(ddf, 'log_x', 'log_y', ds.count('i32')), out)
+    assert_eq_xr(c_logxy.points(ddf, 'log_x', 'log_y', ds.count('i32')), out)
 
 
-def test_line():
+@pytest.mark.parametrize('DataFrame', DataFrames)
+def test_line(DataFrame):
     axis = ds.core.LinearAxis()
     lincoords = axis.compute_index(axis.compute_scale_and_translate((-3., 3.), 7), 7)
 
-    df = pd.DataFrame({'x': [4, 0, -4, -3, -2, -1.9, 0, 10, 10, 0, 4],
-                       'y': [0, -4, 0, 1, 2, 2.1, 4, 20, 30, 4, 0]})
-    ddf = dd.from_pandas(df, npartitions=2)
+    ddf = DataFrame({'x': [4, 0, -4, -3, -2, -1.9, 0, 10, 10, 0, 4],
+                     'y': [0, -4, 0, 1, 2, 2.1, 4, 20, 30, 4, 0]})
     cvs = ds.Canvas(plot_width=7, plot_height=7,
                     x_range=(-3, 3), y_range=(-3, 3))
     agg = cvs.line(ddf, 'x', 'y', ds.count())
@@ -281,13 +344,14 @@ def test_line():
                     [0, 0, 1, 0, 1, 0, 0]], dtype='i4')
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
-    assert_eq(agg, out)
+    assert_eq_xr(agg, out)
 
 
 # # Line tests
-@pytest.mark.parametrize('df,x,y,ax', [
+@pytest.mark.parametrize('DataFrame', DataFrames)
+@pytest.mark.parametrize('df_kwargs,x,y,ax', [
     # axis1 none constant
-    (pd.DataFrame({
+    (dict(data={
         'x0': [4, -4, 4],
         'x1': [0,  0, 0],
         'x2': [-4, 4, -4],
@@ -297,20 +361,20 @@ def test_line():
     }), ['x0', 'x1', 'x2'], ['y0', 'y1', 'y2'], 1),
 
     # axis1 x constant
-    (pd.DataFrame({
+    (dict(data={
         'y0': [0, 0,  0],
         'y1': [0, 4, -4],
         'y2': [0, 0,  0]
     }), np.array([-4, 0, 4]), ['y0', 'y1', 'y2'], 1),
 
     # axis0 single
-    (pd.DataFrame({
+    (dict(data={
         'x': [4, 0, -4, np.nan, -4, 0, 4, np.nan, 4, 0, -4],
         'y': [0, -4, 0, np.nan, 0, 4, 0, np.nan, 0, 0, 0],
     }), 'x', 'y', 0),
 
     # axis0 multi
-    (pd.DataFrame({
+    (dict(data={
         'x0': [4,  0, -4],
         'x1': [-4, 0,  4],
         'x2': [4,  0, -4],
@@ -320,7 +384,7 @@ def test_line():
     }), ['x0', 'x1', 'x2'], ['y0', 'y1', 'y2'], 0),
 
     # axis0 multi with string
-    (pd.DataFrame({
+    (dict(data={
         'x0': [-4,  0, 4],
         'y0': [0, -4,  0],
         'y1': [0,  4,  0],
@@ -328,17 +392,20 @@ def test_line():
     }), 'x0', ['y0', 'y1', 'y2'], 0),
 
     # axis1 RaggedArray
-    (pd.DataFrame({
+    (dict(data={
         'x': [[4, 0, -4], [-4, 0, 4, 4, 0, -4]],
         'y': [[0, -4, 0], [0, 4, 0, 0, 0, 0]],
     }, dtype='Ragged[int64]'), 'x', 'y', 1),
 ])
-def test_line_manual_range(df, x, y, ax):
+def test_line_manual_range(DataFrame, df_kwargs, x, y, ax):
+    if DataFrame is dask_cudf_DataFrame:
+        if df_kwargs.get('dtype', '').startswith('Ragged'):
+            pytest.skip("Ragged array not supported with cudf")
+
     axis = ds.core.LinearAxis()
     lincoords = axis.compute_index(axis.compute_scale_and_translate((-3., 3.), 7), 7)
 
-    ddf = dd.from_pandas(df, npartitions=2)
-
+    ddf = DataFrame(**df_kwargs)
     cvs = ds.Canvas(plot_width=7, plot_height=7,
                     x_range=(-3, 3), y_range=(-3, 3))
 
@@ -354,12 +421,13 @@ def test_line_manual_range(df, x, y, ax):
 
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
-    assert_eq(agg, out)
+    assert_eq_xr(agg, out)
 
 
-@pytest.mark.parametrize('df,x,y,ax', [
+@pytest.mark.parametrize('DataFrame', DataFrames)
+@pytest.mark.parametrize('df_kwargs,x,y,ax', [
     # axis1 none constant
-    (pd.DataFrame({
+    (dict(data={
         'x0': [0,  0, 0],
         'x1': [-4, 0, 4],
         'x2': [0,  0, 0],
@@ -369,20 +437,20 @@ def test_line_manual_range(df, x, y, ax):
     }), ['x0', 'x1', 'x2'], ['y0', 'y1', 'y2'], 1),
 
     # axis1 y constant
-    (pd.DataFrame({
+    (dict(data={
         'x0': [0,  0, 0],
         'x1': [-4, 0, 4],
         'x2': [0,  0, 0],
     }), ['x0', 'x1', 'x2'], np.array([-4, 0, 4]), 1),
 
     # axis0 single
-    (pd.DataFrame({
+    (dict(data={
         'x': [0, -4, 0, np.nan, 0, 0, 0, np.nan, 0, 4, 0],
         'y': [-4, 0, 4, np.nan, 4, 0, -4, np.nan, -4, 0, 4],
     }), 'x', 'y', 0),
 
     # axis0 multi
-    (pd.DataFrame({
+    (dict(data={
         'x0': [0, -4,  0],
         'x1': [0,  0,  0],
         'x2': [0,  4,  0],
@@ -392,7 +460,7 @@ def test_line_manual_range(df, x, y, ax):
     }), ['x0', 'x1', 'x2'], ['y0', 'y1', 'y2'], 0),
 
     # axis0 multi with string
-    (pd.DataFrame({
+    (dict(data={
         'x0': [0, -4,  0],
         'x1': [0,  0,  0],
         'x2': [0,  4,  0],
@@ -400,18 +468,22 @@ def test_line_manual_range(df, x, y, ax):
     }), ['x0', 'x1', 'x2'], 'y0', 0),
 
     # axis1 RaggedArray
-    (pd.DataFrame({
+    (dict(data={
         'x': [[0, -4, 0], [0, 0, 0], [0, 4, 0]],
         'y': [[-4, 0, 4], [4, 0, -4], [-4, 0, 4]],
     }, dtype='Ragged[int64]'), 'x', 'y', 1),
 
 ])
-def test_line_autorange(df, x, y, ax):
+def test_line_autorange(DataFrame, df_kwargs, x, y, ax):
+    if DataFrame is dask_cudf_DataFrame:
+        if df_kwargs.get('dtype', '').startswith('Ragged'):
+            pytest.skip("Ragged array not supported with cudf")
+
     axis = ds.core.LinearAxis()
     lincoords = axis.compute_index(
         axis.compute_scale_and_translate((-4., 4.), 9), 9)
 
-    ddf = dd.from_pandas(df, npartitions=2)
+    ddf = DataFrame(**df_kwargs)
 
     cvs = ds.Canvas(plot_width=9, plot_height=9)
 
@@ -429,17 +501,12 @@ def test_line_autorange(df, x, y, ax):
 
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
-    assert_eq(agg, out)
+    assert_eq_xr(agg, out)
 
 
-def test_line_x_constant_autorange():
+@pytest.mark.parametrize('DataFrame', DataFrames)
+def test_line_x_constant_autorange(DataFrame):
     # axis1 y constant
-    df = pd.DataFrame({
-        'y0': [0, 0, 0],
-        'y1': [-4, 0, 4],
-        'y2': [0, 0, 0],
-    })
-
     x = np.array([-4, 0, 4])
     y = ['y0', 'y1', 'y2']
     ax = 1
@@ -448,7 +515,11 @@ def test_line_x_constant_autorange():
     lincoords = axis.compute_index(
         axis.compute_scale_and_translate((-4., 4.), 9), 9)
 
-    ddf = dd.from_pandas(df, npartitions=2)
+    ddf = DataFrame({
+        'y0': [0, 0, 0],
+        'y1': [-4, 0, 4],
+        'y2': [0, 0, 0],
+    })
 
     cvs = ds.Canvas(plot_width=9, plot_height=9)
 
@@ -466,10 +537,11 @@ def test_line_x_constant_autorange():
 
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
-    assert_eq(agg, out)
+    assert_eq_xr(agg, out)
 
 
-def test_log_axis_line():
+@pytest.mark.parametrize('ddf', ddfs)
+def test_log_axis_line(ddf):
     axis = ds.core.LogAxis()
     logcoords = axis.compute_index(axis.compute_scale_and_translate((1, 10), 2), 2)
 
@@ -479,22 +551,24 @@ def test_log_axis_line():
     sol = np.array([[5, 5], [5, 5]], dtype='i4')
     out = xr.DataArray(sol, coords=[lincoords, logcoords],
                        dims=['y', 'log_x'])
-    assert_eq(c_logx.line(ddf, 'log_x', 'y', ds.count('i32')), out)
+
+    assert_eq_xr(c_logx.line(ddf, 'log_x', 'y', ds.count('i32')), out)
     out = xr.DataArray(sol, coords=[logcoords, lincoords],
                        dims=['log_y', 'x'])
-    assert_eq(c_logy.line(ddf, 'x', 'log_y', ds.count('i32')), out)
+    assert_eq_xr(c_logy.line(ddf, 'x', 'log_y', ds.count('i32')), out)
     out = xr.DataArray(sol, coords=[logcoords, logcoords],
                        dims=['log_y', 'log_x'])
-    assert_eq(c_logxy.line(ddf, 'log_x', 'log_y', ds.count('i32')), out)
+    assert_eq_xr(c_logxy.line(ddf, 'log_x', 'log_y', ds.count('i32')), out)
 
 
-def test_auto_range_line():
+@pytest.mark.parametrize('DataFrame', DataFrames)
+def test_auto_range_line(DataFrame):
     axis = ds.core.LinearAxis()
     lincoords = axis.compute_index(axis.compute_scale_and_translate((-10., 10.), 5), 5)
 
-    df = pd.DataFrame({'x': [-10,  0, 10,   0, -10],
-                       'y': [  0, 10,  0, -10,   0]})
-    ddf = dd.from_pandas(df, npartitions=2)
+    ddf = DataFrame({'x': [-10,  0, 10,   0, -10],
+                     'y': [  0, 10,  0, -10,   0]})
+
     cvs = ds.Canvas(plot_width=5, plot_height=5)
     agg = cvs.line(ddf, 'x', 'y', ds.count())
     sol = np.array([[0, 0, 1, 0, 0],
@@ -504,12 +578,13 @@ def test_auto_range_line():
                     [0, 0, 1, 0, 0]], dtype='i4')
     out = xr.DataArray(sol, coords=[lincoords, lincoords],
                        dims=['y', 'x'])
-    assert_eq(agg, out)
+    assert_eq_xr(agg, out)
 
 
-@pytest.mark.parametrize('df,x,y,ax', [
+@pytest.mark.parametrize('DataFrame', DataFrames)
+@pytest.mark.parametrize('df_kwargs,x,y,ax', [
     # axis1 none constant
-    (pd.DataFrame({
+    (dict(data={
         'x0': [-4, np.nan],
         'x1': [-2, 2],
         'x2': [0, 4],
@@ -519,13 +594,13 @@ def test_auto_range_line():
     }, dtype='float32'), ['x0', 'x1', 'x2'], ['y0', 'y1', 'y2'], 1),
 
     # axis0 single
-    (pd.DataFrame({
+    (dict(data={
         'x': [-4, -2, 0, np.nan, 2, 4],
         'y': [0, -4, 0, np.nan, 4, 0],
     }), 'x', 'y', 0),
 
     # axis0 multi
-    (pd.DataFrame({
+    (dict(data={
         'x0': [-4, -2, 0],
         'x1': [np.nan, 2, 4],
         'y0': [0, -4, 0],
@@ -533,12 +608,16 @@ def test_auto_range_line():
     }, dtype='float32'), ['x0', 'x1'], ['y0', 'y1'], 0),
 
     # axis1 ragged arrays
-    (pd.DataFrame({
-        'x': pd.array([[-4, -2, 0], [2, 4]], dtype='Ragged[float32]'),
-        'y': pd.array([[0, -4, 0], [4, 0]], dtype='Ragged[float32]')
-    }), 'x', 'y', 1)
+    (dict(data={
+        'x': pd.array([[-4, -2, 0], [2, 4]]),
+        'y': pd.array([[0, -4, 0], [4, 0]])
+    }, dtype='Ragged[float32]'), 'x', 'y', 1)
 ])
-def test_area_to_zero_fixedrange(df, x, y, ax):
+def test_area_to_zero_fixedrange(DataFrame, df_kwargs, x, y, ax):
+    if DataFrame is dask_cudf_DataFrame:
+        if df_kwargs.get('dtype', '').startswith('Ragged'):
+            pytest.skip("Ragged array not supported with cudf")
+
     axis = ds.core.LinearAxis()
     lincoords_y = axis.compute_index(
         axis.compute_scale_and_translate((-2.25, 2.25), 5), 5)
@@ -549,7 +628,7 @@ def test_area_to_zero_fixedrange(df, x, y, ax):
     cvs = ds.Canvas(plot_width=9, plot_height=5,
                     x_range=[-3.75, 3.75], y_range=[-2.25, 2.25])
 
-    ddf = dd.from_pandas(df, npartitions=2)
+    ddf = DataFrame(**df_kwargs)
 
     agg = cvs.area(ddf, x, y, ds.count(), axis=ax)
 
@@ -562,12 +641,13 @@ def test_area_to_zero_fixedrange(df, x, y, ax):
 
     out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
                        dims=['y', 'x'])
-    assert_eq(agg, out)
+    assert_eq_xr(agg, out)
 
 
-@pytest.mark.parametrize('df,x,y,ax', [
+@pytest.mark.parametrize('DataFrame', DataFrames)
+@pytest.mark.parametrize('df_kwargs,x,y,ax', [
     # axis1 none constant
-    (pd.DataFrame({
+    (dict(data={
         'x0': [-4, 0],
         'x1': [-2, 2],
         'x2': [0, 4],
@@ -577,7 +657,7 @@ def test_area_to_zero_fixedrange(df, x, y, ax):
     }, dtype='float32'), ['x0', 'x1', 'x2'], ['y0', 'y1', 'y2'], 1),
 
     # axis1 y constant
-    (pd.DataFrame({
+    (dict(data={
         'x0': [-4, 0],
         'x1': [-2, 2],
         'x2': [0, 4],
@@ -585,13 +665,13 @@ def test_area_to_zero_fixedrange(df, x, y, ax):
      ['x0', 'x1', 'x2'], np.array([0, -4, 0], dtype='float32'), 1),
 
     # axis0 single
-    (pd.DataFrame({
+    (dict(data={
         'x': [-4, -2, 0, 0, 2, 4],
         'y': [0, -4, 0, 0, -4, 0],
     }), 'x', 'y', 0),
 
     # axis0 multi
-    (pd.DataFrame({
+    (dict(data={
         'x0': [-4, -2, 0],
         'x1': [0, 2, 4],
         'y0': [0, -4, 0],
@@ -599,19 +679,23 @@ def test_area_to_zero_fixedrange(df, x, y, ax):
     }, dtype='float32'), ['x0', 'x1'], ['y0', 'y1'], 0),
 
     # axis0 multi, y string
-    (pd.DataFrame({
+    (dict(data={
         'x0': [-4, -2, 0],
         'x1': [0, 2, 4],
         'y0': [0, -4, 0],
     }, dtype='float32'), ['x0', 'x1'], 'y0', 0),
 
     # axis1 ragged arrays
-    (pd.DataFrame({
-        'x': pd.array([[-4, -2, 0], [0, 2, 4]], dtype='Ragged[float32]'),
-        'y': pd.array([[0, -4, 0], [0, -4, 0]], dtype='Ragged[float32]')
-    }), 'x', 'y', 1)
+    (dict(data={
+        'x': [[-4, -2, 0], [0, 2, 4]],
+        'y': [[0, -4, 0], [0, -4, 0]]
+    }, dtype='Ragged[float32]'), 'x', 'y', 1)
 ])
-def test_area_to_zero_autorange(df, x, y, ax):
+def test_area_to_zero_autorange(DataFrame, df_kwargs, x, y, ax):
+    if DataFrame is dask_cudf_DataFrame:
+        if df_kwargs.get('dtype', '').startswith('Ragged'):
+            pytest.skip("Ragged array not supported with cudf")
+
     axis = ds.core.LinearAxis()
     lincoords_y = axis.compute_index(
         axis.compute_scale_and_translate((-4., 0.), 7), 7)
@@ -620,7 +704,7 @@ def test_area_to_zero_autorange(df, x, y, ax):
 
     cvs = ds.Canvas(plot_width=13, plot_height=7)
 
-    ddf = dd.from_pandas(df, npartitions=2)
+    ddf = DataFrame(**df_kwargs)
     agg = cvs.area(ddf, x, y, ds.count(), axis=ax)
 
     sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
@@ -634,12 +718,13 @@ def test_area_to_zero_autorange(df, x, y, ax):
 
     out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
                        dims=['y', 'x'])
-    assert_eq(agg, out)
+    assert_eq_xr(agg, out)
 
 
-@pytest.mark.parametrize('df,x,y,ax', [
+@pytest.mark.parametrize('DataFrame', DataFrames)
+@pytest.mark.parametrize('df_kwargs,x,y,ax', [
     # axis1 none constant
-    (pd.DataFrame({
+    (dict(data={
         'x0': [-4, np.nan],
         'x1': [-2, 2],
         'x2': [0, 4],
@@ -649,13 +734,13 @@ def test_area_to_zero_autorange(df, x, y, ax):
     }, dtype='float32'), ['x0', 'x1', 'x2'], ['y0', 'y1', 'y2'], 1),
 
     # axis0 single
-    (pd.DataFrame({
+    (dict(data={
         'x': [-4, -2, 0, np.nan, 2, 4],
         'y': [0, -4, 0, np.nan, 4, 0],
     }), 'x', 'y', 0),
 
     # axis0 multi
-    (pd.DataFrame({
+    (dict(data={
         'x0': [-4, -2, 0],
         'x1': [np.nan, 2, 4],
         'y0': [0, -4, 0],
@@ -663,12 +748,16 @@ def test_area_to_zero_autorange(df, x, y, ax):
     }, dtype='float32'), ['x0', 'x1'], ['y0', 'y1'], 0),
 
     # axis1 ragged arrays
-    (pd.DataFrame({
-        'x': pd.array([[-4, -2, 0], [2, 4]], dtype='Ragged[float32]'),
-        'y': pd.array([[0, -4, 0], [4, 0]], dtype='Ragged[float32]')
-    }), 'x', 'y', 1)
+    (dict(data={
+        'x': [[-4, -2, 0], [2, 4]],
+        'y': [[0, -4, 0], [4, 0]],
+    }, dtype='Ragged[float32]'), 'x', 'y', 1)
 ])
-def test_area_to_zero_autorange_gap(df, x, y, ax):
+def test_area_to_zero_autorange_gap(DataFrame, df_kwargs, x, y, ax):
+    if DataFrame is dask_cudf_DataFrame:
+        if df_kwargs.get('dtype', '').startswith('Ragged'):
+            pytest.skip("Ragged array not supported with cudf")
+
     axis = ds.core.LinearAxis()
     lincoords_y = axis.compute_index(
         axis.compute_scale_and_translate((-4., 4.), 7), 7)
@@ -677,7 +766,7 @@ def test_area_to_zero_autorange_gap(df, x, y, ax):
 
     cvs = ds.Canvas(plot_width=13, plot_height=7)
 
-    ddf = dd.from_pandas(df, npartitions=2)
+    ddf = DataFrame(**df_kwargs)
 
     agg = cvs.area(ddf, x, y, ds.count(), axis=ax)
 
@@ -692,12 +781,13 @@ def test_area_to_zero_autorange_gap(df, x, y, ax):
 
     out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
                        dims=['y', 'x'])
-    assert_eq(agg, out)
+    assert_eq_xr(agg, out)
 
 
-@pytest.mark.parametrize('df,x,y,y_stack,ax', [
+@pytest.mark.parametrize('DataFrame', DataFrames)
+@pytest.mark.parametrize('df_kwargs,x,y,y_stack,ax', [
     # axis1 none constant
-    (pd.DataFrame({
+    (dict(data={
         'x0': [-4, 0],
         'x1': [-2, 2],
         'x2': [0, 4],
@@ -711,7 +801,7 @@ def test_area_to_zero_autorange_gap(df, x, y, ax):
      ['x0', 'x1', 'x2'], ['y0', 'y1', 'y2'], ['y3', 'y4', 'y5'], 1),
 
     # axis1 y constant
-    (pd.DataFrame({
+    (dict(data={
         'x0': [-4, 0],
         'x1': [-2, 2],
         'x2': [0, 4],
@@ -721,14 +811,14 @@ def test_area_to_zero_autorange_gap(df, x, y, ax):
      np.array([0, -2, 0], dtype='float32'), 1),
 
     # axis0 single
-    (pd.DataFrame({
+    (dict(data={
         'x': [-4, -2, 0, 0, 2, 4],
         'y': [0, -4, 0, 0, -4, 0],
         'y_stack': [0, -2, 0, 0, -2, 0],
     }), 'x', 'y', 'y_stack', 0),
 
     # axis0 multi
-    (pd.DataFrame({
+    (dict(data={
         'x0': [-4, -2, 0],
         'x1': [0, 2, 4],
         'y0': [0, -4, 0],
@@ -738,7 +828,7 @@ def test_area_to_zero_autorange_gap(df, x, y, ax):
     }, dtype='float32'), ['x0', 'x1'], ['y0', 'y1'], ['y2', 'y3'], 0),
 
     # axis0 multi, y string
-    (pd.DataFrame({
+    (dict(data={
         'x0': [-4, -2, 0],
         'x1': [0, 2, 4],
         'y0': [0, -4, 0],
@@ -746,13 +836,17 @@ def test_area_to_zero_autorange_gap(df, x, y, ax):
     }, dtype='float32'), ['x0', 'x1'], 'y0', 'y2', 0),
 
     # axis1 ragged arrays
-    (pd.DataFrame({
-        'x': pd.array([[-4, -2, 0], [0, 2, 4]], dtype='Ragged[float32]'),
-        'y': pd.array([[0, -4, 0], [0, -4, 0]], dtype='Ragged[float32]'),
-        'y_stack': pd.array([[0, -2, 0], [0, -2, 0]], dtype='Ragged[float32]')
-    }), 'x', 'y', 'y_stack', 1)
+    (dict(data={
+        'x': [[-4, -2, 0], [0, 2, 4]],
+        'y': [[0, -4, 0], [0, -4, 0]],
+        'y_stack': [[0, -2, 0], [0, -2, 0]]
+    }, dtype='Ragged[float32]'), 'x', 'y', 'y_stack', 1)
 ])
-def test_area_to_line_autorange(df, x, y, y_stack, ax):
+def test_area_to_line_autorange(DataFrame, df_kwargs, x, y, y_stack, ax):
+    if DataFrame is dask_cudf_DataFrame:
+        if df_kwargs.get('dtype', '').startswith('Ragged'):
+            pytest.skip("Ragged array not supported with cudf")
+
     axis = ds.core.LinearAxis()
     lincoords_y = axis.compute_index(
         axis.compute_scale_and_translate((-4., 0.), 7), 7)
@@ -761,7 +855,7 @@ def test_area_to_line_autorange(df, x, y, y_stack, ax):
 
     cvs = ds.Canvas(plot_width=13, plot_height=7)
 
-    ddf = dd.from_pandas(df, npartitions=2)
+    ddf = DataFrame(**df_kwargs)
     agg = cvs.area(ddf, x, y, ds.count(), axis=ax, y_stack=y_stack)
 
     sol = np.array([[0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
@@ -775,12 +869,13 @@ def test_area_to_line_autorange(df, x, y, y_stack, ax):
 
     out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
                        dims=['y', 'x'])
-    assert_eq(agg, out)
+    assert_eq_xr(agg, out)
 
 
-@pytest.mark.parametrize('df,x,y,y_stack,ax', [
+@pytest.mark.parametrize('DataFrame', DataFrames)
+@pytest.mark.parametrize('df_kwargs,x,y,y_stack,ax', [
     # axis1 none constant
-    (pd.DataFrame({
+    (dict(data={
         'x0': [-4, np.nan],
         'x1': [-2, 2],
         'x2': [0, 4],
@@ -794,14 +889,14 @@ def test_area_to_line_autorange(df, x, y, y_stack, ax):
      ['x0', 'x1', 'x2'], ['y0', 'y1', 'y2'], ['y4', 'y5', 'y6'], 1),
 
     # axis0 single
-    (pd.DataFrame({
+    (dict(data={
         'x': [-4, -2, 0, np.nan, 2, 4],
         'y': [0, -4, 0, np.nan, 4, 0],
         'y_stack': [0, 0, 0, 0, 0, 0],
     }), 'x', 'y', 'y_stack', 0),
 
     # axis0 multi
-    (pd.DataFrame({
+    (dict(data={
         'x0': [-4, -2, 0],
         'x1': [np.nan, 2, 4],
         'y0': [0, -4, 0],
@@ -811,13 +906,17 @@ def test_area_to_line_autorange(df, x, y, y_stack, ax):
     }, dtype='float32'), ['x0', 'x1'], ['y0', 'y1'], ['y2', 'y3'], 0),
 
     # axis1 ragged arrays
-    (pd.DataFrame({
-        'x': pd.array([[-4, -2, 0], [2, 4]], dtype='Ragged[float32]'),
-        'y': pd.array([[0, -4, 0], [4, 0]], dtype='Ragged[float32]'),
-        'y_stack': pd.array([[0, 0, 0], [0, 0]], dtype='Ragged[float32]')
-    }), 'x', 'y', 'y_stack', 1)
+    (dict(data={
+        'x': [[-4, -2, 0], [2, 4]],
+        'y': [[0, -4, 0], [4, 0]],
+        'y_stack': [[0, 0, 0], [0, 0]],
+    }, dtype='Ragged[float32]'), 'x', 'y', 'y_stack', 1)
 ])
-def test_area_to_line_autorange_gap(df, x, y, y_stack, ax):
+def test_area_to_line_autorange_gap(DataFrame, df_kwargs, x, y, y_stack, ax):
+    if DataFrame is dask_cudf_DataFrame:
+        if df_kwargs.get('dtype', '').startswith('Ragged'):
+            pytest.skip("Ragged array not supported with cudf")
+
     axis = ds.core.LinearAxis()
     lincoords_y = axis.compute_index(
         axis.compute_scale_and_translate((-4., 4.), 7), 7)
@@ -826,7 +925,7 @@ def test_area_to_line_autorange_gap(df, x, y, y_stack, ax):
 
     cvs = ds.Canvas(plot_width=13, plot_height=7)
 
-    ddf = dd.from_pandas(df, npartitions=2)
+    ddf = DataFrame(**df_kwargs)
 
     # When a line is specified to fill to, this line is not included in
     # the fill.  So we expect the y=0 line to not be filled.
@@ -843,7 +942,7 @@ def test_area_to_line_autorange_gap(df, x, y, y_stack, ax):
 
     out = xr.DataArray(sol, coords=[lincoords_y, lincoords_x],
                        dims=['y', 'x'])
-    assert_eq(agg, out)
+    assert_eq_xr(agg, out)
 
 
 def test_trimesh_no_double_edge():

--- a/datashader/tests/test_glyphs.py
+++ b/datashader/tests/test_glyphs.py
@@ -54,7 +54,7 @@ map_onto_pixel_for_triangle = _build_map_onto_pixel_for_triangle(mapper, mapper)
 # Line rasterization
 expand_aggs_and_cols = Glyph._expand_aggs_and_cols(append, 1)
 _draw_segment = _build_draw_segment(append, map_onto_pixel_for_line, expand_aggs_and_cols)
-extend_line = _build_extend_line_axis0(_draw_segment, expand_aggs_and_cols)
+extend_line, _ = _build_extend_line_axis0(_draw_segment, expand_aggs_and_cols)
 
 # Triangles rasterization
 draw_triangle, draw_triangle_interp = _build_draw_triangle(tri_append)

--- a/datashader/tests/test_pandas.py
+++ b/datashader/tests/test_pandas.py
@@ -8,6 +8,7 @@ import datashader as ds
 
 import pytest
 
+from datashader.datatypes import RaggedDtype
 
 df_pd = pd.DataFrame({'x': np.array(([0.] * 10 + [1] * 10)),
                       'y': np.array(([0.] * 5 + [1] * 5 + [0] * 5 + [1] * 5)),
@@ -24,8 +25,20 @@ df_pd.f32[2] = np.nan
 df_pd.f64[2] = np.nan
 dfs_pd = [df_pd]
 
-dfs = [df_pd]
-DataFrames = [pd.DataFrame]
+try:
+    import cudf
+    import cupy
+    def cudf_DataFrame(*args, **kwargs):
+        return cudf.DataFrame.from_pandas(
+            pd.DataFrame(*args, **kwargs), nan_as_null=False
+        )
+    df_cuda = cudf_DataFrame(df_pd)
+    dfs = [df_pd, df_cuda]
+    DataFrames = [pd.DataFrame, cudf_DataFrame]
+except ImportError:
+    cudf = cupy = None
+    dfs = [df_pd]
+    DataFrames = [pd.DataFrame]
 
 c = ds.Canvas(plot_width=2, plot_height=2, x_range=(0, 1), y_range=(0, 1))
 c_logx = ds.Canvas(plot_width=2, plot_height=2, x_range=(1, 10),
@@ -44,12 +57,18 @@ dims = ['y', 'x']
 def assert_eq_xr(agg, b):
     """Assert that two xarray DataArrays are equal, handling the possibility
     that the two DataArrays may be backed by ndarrays of different types"""
+    if cupy and isinstance(agg.data, cupy.ndarray):
+        agg = xr.DataArray(
+            cupy.asnumpy(agg.data), coords=agg.coords, dims=agg.dims
+        )
     assert agg.equals(b)
 
 
 def assert_eq_ndarray(data, b):
     """Assert that two ndarrays are equal, handling the possibility that the
     ndarrays are of different types"""
+    if cupy and isinstance(data, cupy.ndarray):
+        data = cupy.asnumpy(data)
     np.testing.assert_equal(data, b)
 
 
@@ -63,7 +82,10 @@ def floats(n):
 def values(s):
     """Get numpy array of values from pandas-like Series, handling Series
     of different types"""
-    return s.values
+    if cudf and isinstance(s, cudf.Series):
+        return s.to_array(fillna=np.nan)
+    else:
+        return s.values
 
 
 @pytest.mark.parametrize('df', dfs)
@@ -685,6 +707,10 @@ def test_bug_570():
     }], 'x', 'y', 1)
 ])
 def test_line_manual_range(DataFrame, df_args, x, y, ax):
+    if cudf and DataFrame is cudf_DataFrame:
+        if isinstance(getattr(df_args[0].get('x', []), 'dtype', ''), RaggedDtype):
+            pytest.skip("cudf DataFrames do not support extension types")
+
     df = DataFrame(*df_args)
 
     axis = ds.core.LinearAxis()
@@ -757,6 +783,10 @@ def test_line_manual_range(DataFrame, df_args, x, y, ax):
     }], 'x', 'y', 1)
 ])
 def test_line_autorange(DataFrame, df_args, x, y, ax):
+    if cudf and DataFrame is cudf_DataFrame:
+        if isinstance(getattr(df_args[0].get('x', []), 'dtype', ''), RaggedDtype):
+            pytest.skip("cudf DataFrames do not support extension types")
+
     df = DataFrame(*df_args)
 
     axis = ds.core.LinearAxis()
@@ -922,6 +952,10 @@ def test_line_autorange_axis1_ragged():
     }), 'x', 'y', 1)
 ])
 def test_area_to_zero_fixedrange(DataFrame, df_kwargs, x, y, ax):
+    if cudf and DataFrame is cudf_DataFrame:
+        if isinstance(getattr(df_kwargs['data'].get('x', []), 'dtype', ''), RaggedDtype):
+            pytest.skip("cudf DataFrames do not support extension types")
+
     df = DataFrame(**df_kwargs)
 
     axis = ds.core.LinearAxis()
@@ -996,6 +1030,10 @@ def test_area_to_zero_fixedrange(DataFrame, df_kwargs, x, y, ax):
     }), 'x', 'y', 1)
 ])
 def test_area_to_zero_autorange(DataFrame, df_kwargs, x, y, ax):
+    if cudf and DataFrame is cudf_DataFrame:
+        if isinstance(getattr(df_kwargs['data'].get('x', []), 'dtype', ''), RaggedDtype):
+            pytest.skip("cudf DataFrames do not support extension types")
+
     df = DataFrame(**df_kwargs)
 
     axis = ds.core.LinearAxis()
@@ -1057,6 +1095,10 @@ def test_area_to_zero_autorange(DataFrame, df_kwargs, x, y, ax):
     }), 'x', 'y', 1)
 ])
 def test_area_to_zero_autorange_gap(DataFrame, df_kwargs, x, y, ax):
+    if cudf and DataFrame is cudf_DataFrame:
+        if isinstance(getattr(df_kwargs['data'].get('x', []), 'dtype', ''), RaggedDtype):
+            pytest.skip("cudf DataFrames do not support extension types")
+
     df = DataFrame(**df_kwargs)
 
     axis = ds.core.LinearAxis()
@@ -1142,6 +1184,10 @@ def test_area_to_zero_autorange_gap(DataFrame, df_kwargs, x, y, ax):
     }), 'x', 'y', 'y_stack', 1)
 ])
 def test_area_to_line_autorange(DataFrame, df_kwargs, x, y, y_stack, ax):
+    if cudf and DataFrame is cudf_DataFrame:
+        if isinstance(getattr(df_kwargs['data'].get('x', []), 'dtype', ''), RaggedDtype):
+            pytest.skip("cudf DataFrames do not support extension types")
+
     df = DataFrame(**df_kwargs)
 
     axis = ds.core.LinearAxis()

--- a/datashader/tests/test_transfer_functions.py
+++ b/datashader/tests/test_transfer_functions.py
@@ -27,8 +27,15 @@ def build_agg(array_module=np):
     agg = xr.Dataset(dict(a=s_a, b=s_b, c=s_c))
     return agg
 
-aggs = [build_agg(np)]
-arrays = [np.array]
+
+try:
+    import cupy
+    aggs = [build_agg(np), build_agg(cupy)]
+    arrays = [np.array, cupy.array]
+except ImportError:
+    cupy = None
+    aggs = [build_agg(np)]
+    arrays = [np.array]
 
 int_span = [11, 17]
 float_span = [11.0, 17.0]

--- a/datashader/transfer_functions/_cpu_utils.py
+++ b/datashader/transfer_functions/_cpu_utils.py
@@ -1,0 +1,35 @@
+from datashader.utils import ngjit
+
+
+@ngjit
+def masked_clip_2d(data, mask, lower, upper):
+    """
+    Clip the elements of an input array between lower and upper bounds,
+    skipping over elements that are masked out.
+
+    Parameters
+    ----------
+    data: np.ndarray
+        Numeric ndarray that will be clipped in-place
+    mask: np.ndarray
+        Boolean ndarray where True values indicate elements that should be
+        skipped
+    lower: int or float
+        Lower bound to clip to
+    upper: int or float
+        Upper bound to clip to
+
+    Returns
+    -------
+    None
+        data array is modified in-place
+    """
+    for i in range(data.shape[0]):
+        for j in range(data.shape[1]):
+            if mask[i, j]:
+                continue
+            val = data[i, j]
+            if val < lower:
+                data[i, j] = lower
+            elif val > upper:
+                data[i, j] = upper

--- a/datashader/transfer_functions/_cuda_utils.py
+++ b/datashader/transfer_functions/_cuda_utils.py
@@ -1,0 +1,139 @@
+from __future__ import division
+from math import ceil, isnan, nan
+from numba import cuda
+import cupy
+import numpy as np
+
+
+if cupy.result_type is np.result_type:
+    # Workaround until cupy release of https://github.com/cupy/cupy/pull/2249
+    # Without this, cupy.histogram raises an error that cupy.result_type
+    # is not defined.
+    cupy.result_type = lambda *args: np.result_type(
+        *[arg.dtype if isinstance(arg, cupy.ndarray) else arg
+          for arg in args]
+    )
+
+
+def cuda_args(shape):
+    """
+    Compute the blocks-per-grid and threads-per-block parameters for use when
+    invoking cuda kernels
+
+    Parameters
+    ----------
+    shape: int or tuple of ints
+        The shape of the input array that the kernel will parallelize over
+
+    Returns
+    -------
+    tuple
+        Tuple of (blocks_per_grid, threads_per_block)
+    """
+    if isinstance(shape, int):
+        shape = (shape,)
+
+    max_threads = cuda.get_current_device().MAX_THREADS_PER_BLOCK
+    # Note: We divide max_threads by 2.0 to leave room for the registers
+    # occupied by the kernel. For some discussion, see
+    # https://github.com/numba/numba/issues/3798.
+    threads_per_block = int(ceil(max_threads / 2.0) ** (1.0 / len(shape)))
+    tpb = (threads_per_block,) * len(shape)
+    bpg = tuple(int(ceil(d / threads_per_block)) for d in shape)
+    return bpg, tpb
+
+
+# masked_clip_2d
+# --------------
+def masked_clip_2d(data, mask, lower, upper):
+    """
+    Clip the elements of an input array between lower and upper bounds,
+    skipping over elements that are masked out.
+
+    Parameters
+    ----------
+    data: cupy.ndarray
+        Numeric ndarray that will be clipped in-place
+    mask: cupy.ndarray
+        Boolean ndarray where True values indicate elements that should be
+        skipped
+    lower: int or float
+        Lower bound to clip to
+    upper: int or float
+        Upper bound to clip to
+
+    Returns
+    -------
+    None
+        data array is modified in-place
+    """
+    masked_clip_2d_kernel[cuda_args(data.shape)](data, mask, lower, upper)
+
+
+@cuda.jit
+def masked_clip_2d_kernel(data, mask, lower, upper):
+    i, j = cuda.grid(2)
+    maxi, maxj = data.shape
+    if i >= 0 and i < maxi and j >= 0 and j < maxj and not mask[i, j]:
+        cuda.atomic.max(data, (i, j), lower)
+        cuda.atomic.min(data, (i, j), upper)
+
+
+# interp
+# ------
+# When cupy adds cupy.interp support, this function can be removed
+def interp(x, xp, fp, left=None, right=None):
+    """
+    cupy implementation of np.interp.  This function can be removed when an
+    official cupy.interp function is added to the cupy library.
+    """
+    output_y = cupy.zeros(x.shape, dtype=cupy.float64)
+    assert len(x.shape) == 2
+    if left is None:
+        left = fp[0]
+    left = float(left)
+    if right is None:
+        right = fp[-1]
+    right = float(right)
+    interp2d_kernel[cuda_args(x.shape)](
+        x.astype(cupy.float64), xp.astype(cupy.float64), fp.astype(cupy.float64), left, right, output_y
+    )
+    return output_y
+
+
+@cuda.jit
+def interp2d_kernel(x, xp, fp, left, right, output_y):
+    i, j = cuda.grid(2)
+    if i < x.shape[0] and j < x.shape[1]:
+        xval = x[i, j]
+
+        if isnan(xval):
+            output_y[i, j] = nan
+        elif xval < xp[0]:
+            output_y[i, j] = left
+        elif xval >= xp[-1]:
+            output_y[i, j] = right
+        else:
+            # Find indices of xp that straddle xval
+            upper_i = len(xp) - 1
+            lower_i = 0
+            while True:
+                stop_i = 1 + (lower_i + upper_i) // 2
+                if xp[stop_i] < xval:
+                    lower_i = stop_i
+                elif xp[stop_i - 1] > xval:
+                    upper_i = stop_i - 1
+                else:
+                    break
+
+            # Compute interpolate y value
+            x0 = xp[stop_i - 1]
+            x1 = xp[stop_i]
+            y0 = fp[stop_i - 1]
+            y1 = fp[stop_i]
+
+            slope = (y1 - y0) / (x1 - x0)
+            y_interp = y0 + slope * (xval - x0)
+
+            # Update output
+            output_y[i, j] = y_interp


### PR DESCRIPTION
## Overview
This PR adds initial GPU support to Datashader :tada:. This is implemented using a combination of the `cudf` and `cupy` libraries and numba's cuda support.

This work was inspired by the cuDataShader project: https://github.com/rapidsai/cuDataShader.

cc: @jbednar, @philippjfr, @exactlyallan

## Supported Features
The following Datashader features can now be accelerated by an NVIDIA GPU supported by recent versions of `cudf`/`cupy`/`numba`.

 - `Canvas.points` rasterization
 - `Canvas.line` and `Canvas.area` rasterization
 - All reduction operations *except* `var` and `std`. The current algorithm for these is a single pass serial algorithm that doesn't extend to fine-grained parallelization. For GPU parallelization, I think we would want to use a two-pass algorithm (compute the mean during the first pass, then compute the sum of squared difference from the mean in the second pass), but this would require a bit more refactoring to support.
 - `transfer_functions.shade` (both 2D and 3D) inputs
 
 For the `points`/`line`/`area` methods, GPU acceleration is enabled automatically when the input data frame is a `cudf.DataFrame` instance.  In this case, the aggregation results are returned in an xarray `DataArray` that is backed by a `cupy.ndarray` instance (rather than a `numpy.ndarray` instance). This way the aggregation results remain in GPU memory.
 
 The `transfer_functions.shade` function will be GPU accelerated if it is passed an xarray `DataArray` that is backed by a `cupy.ndarray` instance.
 
## Performance
I created the following benchmark notebooks:
 - Benchmark `Canvas.points`: https://anaconda.org/jonmmease/gpu_datashader_points_pr/notebook
 - Benchmark `Canvas.line`: https://anaconda.org/jonmmease/gpu_datashader_lines_pr/notebook
 
For each of these notebooks, I compared the performance of passing a pandas DataFrame (single threaded CPU), a dask DataFrame with 12 partitions (12 threaded CPU on a 14 core workstation), and a cudf DataFrame (GeForce RTX 2080).

### Points with `count` aggregate
Rendering ~100 million points

 - pandas: 1280 ms
 - dask: 284 ms (~4.5x speedup from pandas)
 - cudf: 31.2 ms (~40x speedup from pandas)
 
### Points with `count_cat` aggregate
Rendering ~100 million points

 - pandas: 1690 ms
 - dask: 681 ms (~2.5x speedup from pandas)
 - cudf: 83.6 ms (~20x speedup from pandas)
 
### Line
Rendering 1 million length-10 lines

 - pandas: 2060 ms
 - dask: 317 ms (~6.5x speedup from pandas)
 - cudf: 69.3 ms (~30x speedup from pandas)

## Testing
The test suite is set up to run the GPU tests only if `cupy` and `cudf` are installed. We should talk about how we want to handle CI testing of the GPU code going forward.
