### PR TITLE
Fixed edge bundling performance regression

### DIFF
--- a/datashader/bundling.py
+++ b/datashader/bundling.py
@@ -33,9 +33,9 @@ def distance_between(a, b):
     return (((a[0] - b[0]) ** 2) + ((a[1] - b[1]) ** 2))**(0.5)
 
 
-@nb.jit(forceobj=True)
+@nb.jit
 def resample_segment(segments, new_segments, min_segment_length, max_segment_length, ndims):
-    next_point = np.zeros(ndims)
+    next_point = np.zeros(ndims, dtype=segments.dtype)
     current_point = segments[0]
     pos = 0
     index = 1

--- a/datashader/layout.py
+++ b/datashader/layout.py
@@ -3,7 +3,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import numba as nb
 import numpy as np
 import param
 import scipy.sparse

--- a/datashader/layout.py
+++ b/datashader/layout.py
@@ -171,7 +171,6 @@ def _merge_points_with_nodes(nodes, points, params):
     return n
 
 
-@nb.jit(forceobj=True)
 def cooling(matrix, points, temperature, params):
     dt = temperature / float(params.iterations + 1)
     displacement = np.zeros((params.dim, len(points)))


### PR DESCRIPTION
There was a serious performance regression in edge bundling caused by https://github.com/pyviz/datashader/pull/763.  On the left is what's on the website from 0.7.0,  on the right is a new build on my recent MacBook Pro.  49 seconds became 582 seconds (9:42):

![image](https://user-images.githubusercontent.com/1695496/66159709-2fe49f00-e5ee-11e9-9294-71b65966b6cf.png)

On investigation, it turns out that that PR was effectively disabling Numba acceleration for a key step in bundling, which did prevent a bunch of warnings from being shown, but resulted in unacceptably slow performance.  The Numba team helped me figure out that the real problem was that the dtype was changing between a default value (used when the loop was not executed) and the typical value (used when the loop was), which made Numba complain a lot.  After fixing that, the performance is now faster than on the website, with no warnings:

![image](https://user-images.githubusercontent.com/1695496/66160048-e21c6680-e5ee-11e9-9adc-4a090add9943.png)


