### PR TITLE
Geospatial fixes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,8 +2,6 @@ environment:
   global:
     CHANNELS: "-c conda-forge -c pyviz/label/dev"
   matrix:
-    - PY: "2.7"
-      CONDA: "C:\\Miniconda-x64"
     - PY: "3.6"
       CONDA: "C:\\Miniconda36-x64"
 

--- a/datashader/geo.py
+++ b/datashader/geo.py
@@ -433,10 +433,13 @@ def bump(width, height, count=None, height_func=None, spread=1):
     if height_func is None:
         height_func = lambda bumps: np.ones(len(bumps))
 
-    bump_xs = np.random.choice(linx, count)
-    bump_ys = np.random.choice(liny, count)
-    locs = np.vstack([bump_xs,bump_ys]).T
-    heights = height_func(locs.tolist())
+    # create 2d array of random x, y for bump locations
+    locs = np.empty((count, 2), dtype=np.uint16)
+    locs[:, 0] = np.random.choice(linx, count)
+    locs[:, 1] = np.random.choice(liny, count)
+
+    heights = height_func(locs)
+
     bumps = _finish_bump(width, height, locs, heights, spread)
     return DataArray(bumps, dims=['y', 'x'], attrs=dict(res=1))
 

--- a/datashader/geo.py
+++ b/datashader/geo.py
@@ -433,10 +433,10 @@ def bump(width, height, count=None, height_func=None, spread=1):
     if height_func is None:
         height_func = lambda bumps: np.ones(len(bumps))
 
-    bump_xs = np.random.choice(linx, count).tolist()
-    bump_ys = np.random.choice(liny, count).tolist()
-    locs = tuple(zip(bump_xs, bump_ys))
-    heights = height_func(locs)
+    bump_xs = np.random.choice(linx, count)
+    bump_ys = np.random.choice(liny, count)
+    locs = np.vstack([bump_xs,bump_ys]).T
+    heights = height_func(locs.tolist())
     bumps = _finish_bump(width, height, locs, heights, spread)
     return DataArray(bumps, dims=['y', 'x'], attrs=dict(res=1))
 

--- a/datashader/spatial/viewshed.py
+++ b/datashader/spatial/viewshed.py
@@ -1,7 +1,10 @@
 import xarray
 import numpy as np
 import math
+
 from math import atan, sqrt, fabs
+from math import pi as PI
+
 import numba as nb
 from numba import jit
 
@@ -31,13 +34,14 @@ CENTER_EVENT = 0
 
 # this value is returned by findMaxValueWithinDist() if there is no key within
 # that distance
-SMALLEST_GRAD = -9999999999999999999999.0
+SMALLEST_GRAD = float('-inf')
 
 PROJ_LL = 0
 PROJ_NONE = -1
 
-PI = math.pi
 
+# Future refactor?:
+# This value is a placeholder for np.nan in integer arrays
 NAN = -9999999999999999
 
 
@@ -95,6 +99,10 @@ class TreeValue:
 
         return self.grad[0]
 
+    def _print_tv(self):
+        print('key=', self.key, 'grad=', self.grad, 'ang=', self.ang,
+              'max_grad=', self.max_grad)
+
 
 class TreeNode:
 
@@ -122,7 +130,7 @@ class TreeNode:
             for l in self.left.__iter__():
                 yield l
 
-        yield self.val.key
+        yield self.val
 
         if self.right != NIL:
             for r in self.right.__iter__():
@@ -395,7 +403,6 @@ class Tree:
 
         cur_node = key_node
         max = SMALLEST_GRAD
-
         while cur_node.parent != NIL:
             if cur_node == cur_node.parent.right:
                 # its the right node of its parent
@@ -623,8 +630,8 @@ class Tree:
             while z.parent != NIL:
                 if z.parent.val.max_grad == z_gradient:
                     if z.parent.val.find_value_min_value() != z_gradient and \
-                        not (z.parent.left.val.max_grad == z_gradient) and \
-                       x.parent.right.val.max_grad == z_gradient:
+                        not (z.parent.left.val.max_grad == z_gradient and
+                             x.parent.right.val.max_grad == z_gradient):
 
                         left = _find_max_value(z.parent.left)
                         right = _find_max_value(z.parent.right)
@@ -690,8 +697,9 @@ class StatusNode:
             self.ang = np.array(angle)
 
     def _print_status_node(self):
-        print(self.row, self.col, self.dist_to_viewpoint,
-              self.grad, self.ang)
+        print("row=", self.row, "col=", self.col, "dist_to_viewpoint=",
+              self.dist_to_viewpoint,
+              "grad=", self.grad, "ang=", self.ang)
 
 
 def _insert_into_status_struct(status_node, tree):
@@ -711,7 +719,7 @@ def _max_grad_in_status_struct(tree, distance, angle, gradient):
     # Note: if there is nothing in the status structure,
     #         it means this cell is VISIBLE
 
-    if not tree.root:
+    if tree.root == NIL or tree.root is None:
         return SMALLEST_GRAD
 
     # it is also possible that the status structure is not empty, but
@@ -846,11 +854,42 @@ class Event:
         self.ang = angle
         self.type = event_type
 
+    def __lt__(self, other_event):
+        if self.row == other_event.row and self.col == other_event.col\
+                and self.type == other_event.type:
+            return False
+
+        assert self.ang >= 0 and other_event.ang >= 0
+
+        if self.ang > other_event.ang:
+            return False
+
+        if self.ang < other_event.ang:
+            return True
+
+        # self.ang == other_event.ang
+        if self.type == EXITING_EVENT:
+            return True
+        if other_event.type == EXITING_EVENT:
+            return False
+        if self.type == ENTERING_EVENT:
+            return False
+        if other_event.type == ENTERING_EVENT:
+            return True
+        return False
+
     # for debug purpose
     def _print_event(self):
-        print('event_type = ', self.type,
-              'row = ', self.row,
+        if self.type == 1:
+            t = "ENTERING   "
+        elif self.type == -1:
+            t = "EXITING    "
+        else:
+            t = "CENTER     "
+
+        print('row = ', self.row,
               'col = ', self.col,
+              'event_type = ', t,
               'elevation = ', self.elev,
               'ang = ', self.ang)
 
@@ -990,8 +1029,8 @@ def _g_distance(e1, n1, e2, n2, proj=PROJ_NONE):
 # unchanged.
 # If viewOptions.doRefr is on then adjust the curved height for
 # the effect of atmospheric refraction too.
-@jit(nb.f8(nb.i8, nb.i8, nb.i8, nb.i8, nb.f8, nb.b1, nb.f8, nb.b1,
-           nb.f8, nb.f8, nb.f8, nb.f8, nb.f8, nb.i8), nopython=True)
+@jit(nb.f8(nb.i8, nb.i8, nb.f8, nb.f8, nb.f8, nb.b1, nb.f8,
+           nb.b1, nb.f8, nb.f8, nb.f8, nb.f8, nb.f8, nb.i8), nopython=True)
 def _adjust_curv(viewpoint_row, viewpoint_col, row, col, h, do_curv, ellps_a,
                  do_refr, refr_coef, west, ew_res, north, ns_res, proj):
     # Adjust the passed height for curvature of the earth
@@ -1027,9 +1066,8 @@ def _set_visibility(visibility_grid, i, j, value):
     return
 
 
-@jit(nb.b1(nb.i8, nb.i8,
-           nb.f8, nb.f8, nb.f8, nb.f8, nb.i8,
-           nb.i8, nb.i8, nb.f8), nopython=True)
+@jit(nb.b1(nb.i8, nb.i8, nb.f8, nb.f8, nb.f8,
+           nb.f8, nb.i8, nb.i8, nb.i8, nb.f8), nopython=True)
 def _outside_max_dist(viewpoint_row, viewpoint_col, west, ew_res, north,
                       ns_res, proj, row, col, max_distance):
     # Determine if the point at (row,col) is outside the maximum distance.
@@ -1321,11 +1359,11 @@ def _calculate_angle(event_x, event_y, viewpoint_x, viewpoint_y):
 
     if viewpoint_x == event_x and viewpoint_y > event_y:
         # between 1st and 2nd quadrant
-        return math.pi / 2
+        return PI / 2
 
     if viewpoint_x == event_x and viewpoint_y < event_y:
         # between 3rd and 4th quadrant
-        return math.pi * 3.0 / 2.0
+        return PI * 3.0 / 2.0
 
     # Calculate angle between (x1, y1) and (x2, y2)
     ang = atan(fabs(event_y - viewpoint_y) / fabs(event_x - viewpoint_x))
@@ -1341,27 +1379,26 @@ def _calculate_angle(event_x, event_y, viewpoint_x, viewpoint_y):
 
     if viewpoint_x > event_x and viewpoint_y > event_y:
         # 2nd quadrant
-        return math.pi - ang
+        return PI - ang
 
     if viewpoint_x > event_x and viewpoint_y == event_y:
         # between 1st and 3rd quadrant
-        return math.pi
+        return PI
 
     if viewpoint_x > event_x and viewpoint_y < event_y:
         # 3rd quadrant
-        return math.pi + ang
+        return PI + ang
 
     if viewpoint_x < event_x and viewpoint_y < event_y:
         # 4th quadrant
-        return math.pi * 2.0 - ang
+        return PI * 2.0 - ang
 
     assert event_x == viewpoint_x and event_y == viewpoint_y
     return 0
 
 
-@jit(nb.f8(nb.i8, nb.i8, nb.f8,
-           nb.i8, nb.i8, nb.f8,
-           nb.f8, nb.f8, nb.f8, nb.f8, nb.i8), nopython=True)
+@jit(nb.f8(nb.f8, nb.f8, nb.f8, nb.i8, nb.i8,
+           nb.f8, nb.f8, nb.f8, nb.f8, nb.f8, nb.i8), nopython=True)
 def _calc_event_grad(row, col, elev, viewpoint_row, viewpoint_col,
                      viewpoint_elev, west, ew_res, north, ns_res, proj):
     # Calculate event gradient
@@ -1419,12 +1456,7 @@ def _calc_dist_n_grad(status_node_row, status_node_col, elev,
         dy = (status_node_row - viewpoint_row) * ns_res
         distance_to_viewpoint = (dx * dx) + (dy * dy)
 
-    if diff_elev == 0:
-        gradient = 0
-        return distance_to_viewpoint, gradient
-
     # PI / 2 above, - PI / 2 below
-
     if distance_to_viewpoint == 0:
         if diff_elev > 0:
             gradient = PI / 2
@@ -1432,7 +1464,6 @@ def _calc_dist_n_grad(status_node_row, status_node_col, elev,
             gradient = - PI / 2
         else:
             gradient = 0
-
     else:
         gradient = atan(diff_elev / sqrt(distance_to_viewpoint))
     return distance_to_viewpoint, gradient
@@ -1669,16 +1700,12 @@ def _viewshed(raster, vp, v_op, g_hd):
                      g_hd=g_hd, data=data, visibility_grid=visibility_grid)
 
     # sort the events radially by ang
-    # s = timer()
-    event_list.sort(key=lambda x: x.ang, reverse=False)
-    # e = timer()
-    # print("sort time ", e - s)
+    event_list.sort()
 
     # create the status structure
     status_struct = _create_status_struct()
 
     # Put cells that are initially on the sweepline into status structure
-
     for i in range(vp.col + 1, g_hd.cols):
         status_node = StatusNode(row=vp.row, col=i)
         e = Event(row=vp.row, col=i)
@@ -1804,7 +1831,6 @@ def _viewshed(raster, vp, v_op, g_hd):
 
         elif etype == CENTER_EVENT:
             # calculate visibility
-
             # consider current ang and gradient
             max = _max_grad_in_status_struct(status_struct,
                                              status_node.dist_to_viewpoint,

--- a/datashader/tests/test_viewshed.py
+++ b/datashader/tests/test_viewshed.py
@@ -7,51 +7,126 @@ from datashader.spatial import viewshed
 import numpy as np
 import pandas as pd
 
-width = 10
-height = 5
-x_range = (-20, 20)
-y_range = (-20, 20)
+# create an empty image of size 5*5
+H = 5
+W = 5
 
+canvas = ds.Canvas(plot_width=W, plot_height=H,
+                   x_range=(-20, 20), y_range=(-20, 20))
 
-df = pd.DataFrame({
-   'x': [-10, -10, -4, -4, 1, 3, 7, 7, 7],
-   'y': [-5, -10, -5, -5, 0, 5, 10, 10, 10]
+empty_df = pd.DataFrame({
+   'x': np.random.normal(.5, 1, 0),
+   'y': np.random.normal(.5, 1, 0)
 })
+empty_agg = canvas.points(empty_df, 'x', 'y')
 
-cvs = ds.Canvas(plot_width=width,
-                plot_height=height,
-                x_range=x_range,
-                y_range=y_range)
+# coordinates
+xs = empty_agg.coords['x'].values
+ys = empty_agg.coords['x'].values
 
-raster = cvs.points(df, x='x', y='y')
+# define some values for observer's elevation to test
+OBS_ELEVS = [-1, 0, 1]
+
+TERRAIN_ELEV_AT_VP = [-1, 0, 1]
+
+@pytest.mark.viewshed
+def test_viewshed_invalid_x_view():
+    OBSERVER_X = xs[0] - 1
+    OBSERVER_Y = 0
+    with pytest.raises(Exception) as e_info: # NOQA
+        viewshed(raster=empty_agg, x=OBSERVER_X, y=OBSERVER_Y,
+                 observer_elev=10)
 
 
 @pytest.mark.viewshed
-def test_viewshed_invalid_x():
-    x = 20e8
-    y = 0
-    with pytest.raises(Exception) as e_info:
-        viewshed(raster=raster, x=x, y=y)
-        assert e_info
+def test_viewshed_invalid_y_view():
+    OBSERVER_X = 0
+    OBSERVER_Y = ys[-1] + 1
+    with pytest.raises(Exception) as e_info: # NOQA
+        viewshed(raster=empty_agg, x=OBSERVER_X, y=OBSERVER_Y,
+                 observer_elev=10)
 
 
 @pytest.mark.viewshed
-def test_viewshed_invalid_y():
-    x = 0
-    y = 20e8
-    with pytest.raises(Exception) as e_info:
-        viewshed(raster=raster, x=x, y=y)
-        assert e_info
+def test_viewshed_output_properties():
+    for obs_elev in OBS_ELEVS:
+        OBSERVER_X = xs[0]
+        OBSERVER_Y = ys[0]
+        v = viewshed(raster=empty_agg, x=OBSERVER_X, y=OBSERVER_Y,
+                     observer_elev=obs_elev)
+
+        assert v.shape[0] == empty_agg.shape[0]
+        assert v.shape[1] == empty_agg.shape[1]
+        assert isinstance(v, xa.DataArray)
+        assert isinstance(v.values, np.ndarray)
+        assert type(v.values[0, 0]) == np.float64
 
 
 @pytest.mark.viewshed
 def test_viewshed():
-    x = 0
-    y = 5
-    v = viewshed(raster=raster, x=x, y=y)
 
-    assert v.shape[0] == raster.values.shape[0]
-    assert v.shape[1] == raster.values.shape[1]
-    assert isinstance(v, xa.DataArray)
-    assert isinstance(v.values, np.ndarray)
-    assert type(v.values[0, 0]) == np.float64
+    # check if a matrix is symmetric
+    def check_symmetric(matrix, rtol=1e-05, atol=1e-08):
+        return np.allclose(matrix, matrix.T, rtol=rtol, atol=atol)
+
+    def get_matrices(y, x, height, width):
+        # indexing 0 1 ... height-1 and 0 1 ... width-1
+        height = height - 1
+        width = width - 1
+
+        # find first matrix's diagonal
+        tmp = min(y, x)
+        f_top_y, f_left_x = y - tmp, x - tmp
+
+        tmp = min(height - y, width - x)
+        f_bottom_y, f_right_x = y + tmp, x + tmp
+
+        # find second matrix's antidiagonal
+        tmp = min(y, width - x)
+        s_top_y, s_right_x = y - tmp, x + tmp
+
+        tmp = min(height - y, x)
+        s_bottom_y, s_left_x = y + tmp, x - tmp
+
+        return (f_top_y, f_left_x, f_bottom_y + 1, f_right_x + 1), \
+               (s_top_y, s_left_x, s_bottom_y + 1, s_right_x + 1)
+
+    # test on 3 scenarios:
+    #   empty image.
+    #   image with all 0s, except 1 cell with a negative value.
+    #   image with all 0s, except 1 cell with a positive value.
+
+    # for each scenario:
+    #   if not empty image,
+    #      observer is located at the same position as the non zero value.
+    #   observer elevation can be: negative, zero, or positive.
+
+    # assertion:
+    #   angle at viewpoint is always 180.
+    #   when the observer is above the terrain, all cells are visible.
+    #   the symmetric property of observer's visibility.
+
+    for obs_elev in OBS_ELEVS:
+        for elev_at_vp in TERRAIN_ELEV_AT_VP:
+            for col_id, x in enumerate(xs):
+                for row_id, y in enumerate(ys):
+                    empty_agg.values[row_id, col_id] = elev_at_vp
+                    v = viewshed(raster=empty_agg, x=x, y=y,
+                                 observer_elev=obs_elev)
+                    # angle at viewpoint is always 180
+                    assert v[row_id, col_id] == 180
+
+                    if obs_elev + elev_at_vp >= 0 and \
+                            obs_elev >= abs(elev_at_vp):
+                        # all cells are visible
+                        assert (v.values > -1).all()
+
+                    b1, b2 = get_matrices(row_id, col_id, H, W)
+                    m1 = v.values[b1[0]:b1[2], b1[1]:b1[3]]
+                    m2 = v.values[b2[0]:b2[2], b2[1]:b2[3]]
+
+                    assert check_symmetric(m1)
+                    assert check_symmetric(m2[::-1])
+
+                    # empty image for next uses
+                    empty_agg.values[row_id, col_id] = 0

--- a/examples/user_guide/8_Geography.ipynb
+++ b/examples/user_guide/8_Geography.ipynb
@@ -282,9 +282,11 @@
     "        out[i] = height if (val > min_val and val < max_val) else 0\n",
     "    return out\n",
     "\n",
-    "T = 800\n",
+    "T = 200000\n",
     "\n",
-    "trees = dsgeo.bump(W, H, count=T,    height_func=partial(heights, min_val=500,  max_val=2000, height=20))\n",
+    "trees  = dsgeo.bump(W, H, count=T//3, height_func=partial(heights, min_val=50,   max_val=500,  height=10))\n",
+    "trees += dsgeo.bump(W, H, count=T,    height_func=partial(heights, min_val=500,  max_val=2000, height=20))\n",
+    "trees += dsgeo.bump(W, H, count=T//3, height_func=partial(heights, min_val=2000, max_val=3000, height=10))\n",
     "\n",
     "tree_colorize = trees.copy()\n",
     "tree_colorize.data[tree_colorize.data == 0] = np.nan\n",
@@ -320,6 +322,29 @@
     "stack(shade(terrain,                  cmap=['black', 'white'], how='linear'),\n",
     "      shade(water,                    cmap=['aqua',  'white']),\n",
     "      shade(dsgeo.hillshade(terrain), cmap=['black', 'white'], how='linear', alpha=128))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "We've now seen a bunch of datashader's `geo` helper functions for working with elevation rasters.\n",
+    "\n",
+    "Let's make our final archipelago scene by stacking `terrain`, `water`, `hillshade`, and `tree_highlights` together into one output image: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stack(shade(terrain + trees,                  cmap=Elevation,          how='linear'),\n",
+    "      shade(water,                            cmap=['aqua','white']),\n",
+    "      shade(dsgeo.hillshade(terrain + trees), cmap=['black', 'white'], how='linear', alpha=128),\n",
+    "      shade(tree_colorize,                    cmap='limegreen',        how='linear'))"
    ]
   },
   {

--- a/examples/user_guide/8_Geography.ipynb
+++ b/examples/user_guide/8_Geography.ipynb
@@ -77,11 +77,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import holoviews as hv, geoviews.tile_sources as gts\n",
+    "import holoviews as hv\n",
     "from holoviews.operation.datashader import datashade, spread\n",
+    "from holoviews.element import tiles\n",
     "hv.extension('bokeh')\n",
     "\n",
-    "gts.EsriImagery() * spread(datashade(hv.Points(df, ['x', 'y']), cmap=\"white\"), px=3)"
+    "pts = spread(datashade(hv.Points(df, ['x', 'y']), cmap=\"white\", width=300, height=100), px=3)\n",
+    "\n",
+    "tiles.EsriImagery() * pts"
    ]
   },
   {
@@ -229,19 +232,11 @@
    "source": [
     "## NDVI\n",
     "\n",
-    "The Normalized Difference Vegetation Index (NDVI) quantifies vegetation by measuring the difference between near-infrared (which vegetation strongly reflects) and red light (which vegetation absorbs).\n",
+    "The [Normalized Difference Vegetation Index](https://en.wikipedia.org/wiki/Normalized_difference_vegetation_index) (NDVI) is a metric designed to detect regions with vegetation by measuring the difference between near-infrared (NIR) light (which vegetation reflects) and red light (which vegetation absorbs).\n",
     "\n",
-    "For example, when you have negative values, it’s highly likely that it’s water. On the other hand, if you have a NDVI value close to +1, there’s a high possibility that it’s dense green leaves.\n",
-    "But when NDVI is close to zero, there isn’t green leaves and it could even be an urbanized area."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The output of *NDVI* ranges from [-1,+1], where `-1` means more \"Red\" radiation while `+1` means more \"NIR\" radiation.\n",
+    "The NDVI ranges over [-1,+1], where `-1` means more \"Red\" radiation while `+1` means more \"NIR\" radiation. NDVI values close to +1.0 suggest areas dense with active green foliage, while strongly negative values suggest cloud cover or snow, and values near zero suggest open water, urban areas, or bare soil. \n",
     "\n",
-    "Below, we simulate the red and near-infrared bands using `datashader.perlin` random noise with different seeds and frequencies.  Green areas should be those > 0, where higher NDVI values would indicate vegetation."
+    "For our synthetic example here, we don't have access to NIR measurements, but we can approximate the results for demonstration purposes by using the green and blue channels of a colormapped image, as those represent a difference in wavelength similar to NIR vs. Red."
    ]
   },
   {
@@ -250,11 +245,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "near_infrared_band = dsgeo.perlin(W, H, freq=(6,   6), seed=1)\n",
-    "red_band           = dsgeo.perlin(W, H, freq=(10, 10), seed=2)\n",
-    "vegetation_index   = dsgeo.ndvi(near_infrared_band, red_band)\n",
+    "import xarray as xr\n",
     "\n",
-    "shade(vegetation_index, cmap=['purple','black','green'], how='linear')"
+    "rgba = stack(shade(terrain, cmap=Elevation, how='linear')).to_pil()\n",
+    "r,g,b,a = [xr.DataArray(np.flipud(np.asarray(rgba.getchannel(c))))/255.0 \n",
+    "           for c in ['R','G','B','A']]\n",
+    "\n",
+    "ndvi = dsgeo.ndvi(nir_agg=g, red_agg=b)\n",
+    "shade(ndvi, cmap=['purple','black','green'], how='linear')"
    ]
   },
   {
@@ -282,18 +280,18 @@
     "        out[i] = height if (val > min_val and val < max_val) else 0\n",
     "    return out\n",
     "\n",
-    "T = 200000\n",
+    "T = 100000\n",
     "\n",
-    "trees  = dsgeo.bump(W, H, count=T//3, height_func=partial(heights, min_val=50,   max_val=500,  height=10))\n",
-    "trees += dsgeo.bump(W, H, count=T,    height_func=partial(heights, min_val=500,  max_val=2000, height=20))\n",
-    "trees += dsgeo.bump(W, H, count=T//3, height_func=partial(heights, min_val=2000, max_val=3000, height=10))\n",
+    "trees = dsgeo.bump(W, H, count=T, height_func=\n",
+    "                   partial(heights, min_val=1300,  max_val=1700, height=20))\n",
     "\n",
     "tree_colorize = trees.copy()\n",
     "tree_colorize.data[tree_colorize.data == 0] = np.nan\n",
+    "hillshade = dsgeo.hillshade(terrain + trees)\n",
     "\n",
-    "stack(shade(terrain + trees,                  cmap=['black', 'white'], how='linear'),\n",
-    "      shade(dsgeo.hillshade(terrain + trees), cmap=['black', 'white'], how='linear', alpha=128),\n",
-    "      shade(tree_colorize,                    cmap='limegreen',        how='linear'))"
+    "stack(shade(terrain,        cmap=['black', 'white'], how='linear'),\n",
+    "      shade(hillshade,      cmap=['black', 'white'], how='linear', alpha=128),\n",
+    "      shade(tree_colorize,  cmap='limegreen',        how='linear'))"
    ]
   },
   {
@@ -303,7 +301,7 @@
     "## Mean\n",
     "The `datashader.mean` function will smooth a given aggregate by using a 3x3 mean convolution filter. Optional parameters include `passes`, which is used to run the mean filter multiple times, and also `excludes` which are values that will not be modified by the mean filter.\n",
     "\n",
-    "Just for fun, let's add a coastal vignette to give out terrain scene a bit more character. Notice the water below now has a nice coastal gradient which adds some realism to our scene."
+    "We can use `mean` to add a coastal vignette to give out terrain scene a bit more character. Notice the water below now has a nice coastal gradient which adds some realism to our scene."
    ]
   },
   {
@@ -316,23 +314,22 @@
     "\n",
     "water = terrain.copy()\n",
     "water.data = np.where(water.data > 0, LAND_CONSTANT, 0)\n",
-    "water = dsgeo.mean(water, passes=10, excludes=[LAND_CONSTANT])\n",
+    "water = dsgeo.mean(water, passes=50, excludes=[LAND_CONSTANT])\n",
     "water.data[water.data == LAND_CONSTANT] = np.nan\n",
     "\n",
-    "stack(shade(terrain,                  cmap=['black', 'white'], how='linear'),\n",
-    "      shade(water,                    cmap=['aqua',  'white']),\n",
-    "      shade(dsgeo.hillshade(terrain), cmap=['black', 'white'], how='linear', alpha=128))"
+    "stack(shade(terrain,    cmap=['black', 'white'], how='linear'),\n",
+    "      shade(water,      cmap=['aqua',  'white']))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Conclusion\n",
+    "## Full scene\n",
     "\n",
-    "We've now seen a bunch of datashader's `geo` helper functions for working with elevation rasters.\n",
+    "We've now seen several of datashader's `geo` helper functions for working with elevation rasters.\n",
     "\n",
-    "Let's make our final archipelago scene by stacking `terrain`, `water`, `hillshade`, and `tree_highlights` together into one output image: "
+    "Let's make a full archipelago scene by stacking `terrain`, `water`, `hillshade`, and `tree_colorize` together into one output image: "
    ]
   },
   {
@@ -341,10 +338,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stack(shade(terrain + trees,                  cmap=Elevation,          how='linear'),\n",
-    "      shade(water,                            cmap=['aqua','white']),\n",
-    "      shade(dsgeo.hillshade(terrain + trees), cmap=['black', 'white'], how='linear', alpha=128),\n",
-    "      shade(tree_colorize,                    cmap='limegreen',        how='linear'))"
+    "stack(shade(terrain,       cmap=Elevation,          how='linear'),\n",
+    "      shade(water,         cmap=['aqua','white']),\n",
+    "      shade(hillshade,     cmap=['black', 'white'], how='linear', alpha=128),\n",
+    "      shade(tree_colorize, cmap='limegreen',        how='linear'))"
    ]
   },
   {
@@ -381,8 +378,7 @@
     "})\n",
     "\n",
     "cvs = ds.Canvas(plot_width=W, plot_height=H,\n",
-    "                x_range=(-20, 20), y_range=(-20, 20))\n",
-    "df, cvs"
+    "                x_range=(-20, 20), y_range=(-20, 20))"
    ]
   },
   {
@@ -456,7 +452,7 @@
    "metadata": {},
    "source": [
     "##### Transform Proximity DataArray\n",
-    "The result of `proximity` is an `xarray.DataArray` with a large api of potential transformations.\n",
+    "Like the other Datashader spatial tools, the result of `proximity` is an `xarray.DataArray` with a large API of potential transformations.\n",
     "\n",
     "Below is an example of using `DataArray.where()` to apply a minimum distance and maximum distance."
    ]
@@ -481,7 +477,7 @@
     "\n",
     "The `datashader.spatial.viewshed` function operates on a given aggregate to calculate the viewshed (the visible cells in the raster) for the given viewpoint (observer) location.  \n",
     "\n",
-    "The visibility model is the following: Two cells are visible to each other if the line-of-sight that connects their centers does not intersect the terrain. If the line-of-sight does not pass through the cell center, elevation is determined using bilinear interpolation."
+    "The visibility model is the following: Two cells are visible to each other if the line of sight that connects their centers does not intersect the terrain. If the line of sight does not pass through the cell center, elevation is determined using bilinear interpolation."
    ]
   },
   {
@@ -524,18 +520,14 @@
     "normal_agg.values = normal_agg.values.astype(\"float64\")\n",
     "normal_shaded = shade(normal_agg)\n",
     "\n",
-    "observer_df = pd.DataFrame({\n",
-    "   'x': [OBSERVER_X],\n",
-    "   'y': [OBSERVER_Y]\n",
-    "})\n",
-    "\n",
+    "observer_df = pd.DataFrame({'x': [OBSERVER_X], 'y': [OBSERVER_Y]})\n",
     "observer_agg = canvas.points(observer_df, 'x', 'y')\n",
-    "observer_shaded = dynspread(shade(observer_agg, cmap=['orange',  'orange']),\n",
-    "                            threshold=1,\n",
-    "                            max_px=4)\n",
+    "observer_shaded = dynspread(shade(observer_agg, cmap=['orange']),\n",
+    "                            threshold=1, max_px=4)\n",
     "\n",
     "normal_illuminated = dsgeo.hillshade(normal_agg)\n",
-    "normal_illuminated_shaded = shade(normal_illuminated, cmap=['black', 'white'], alpha=128, how='linear')\n",
+    "normal_illuminated_shaded = shade(normal_illuminated, cmap=['black', 'white'], \n",
+    "                                  alpha=128, how='linear')\n",
     "\n",
     "stack(normal_illuminated_shaded, observer_shaded)"
    ]
@@ -553,20 +545,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Slow Running...\n",
-    "view = viewshed(normal_agg, x=OBSERVER_X, y=OBSERVER_Y)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "# Will take some time to run...\n",
+    "%time view = viewshed(normal_agg, x=OBSERVER_X, y=OBSERVER_Y)\n",
+    "\n",
     "view_shaded = shade(view, cmap=['white', 'red'], alpha=128, how='linear')\n",
-    "stack(normal_illuminated_shaded,\n",
-    "      observer_shaded,\n",
-    "      view_shaded)                         "
+    "\n",
+    "stack(normal_illuminated_shaded, observer_shaded, view_shaded)                         "
    ]
   },
   {
@@ -576,7 +560,7 @@
     "##### Viewshed on Terrain\n",
     "\n",
     "- Let's take the example above and apply it to our terrain aggregate.\n",
-    "- Notice the use of the `observer_elev` argument which is the height of the observer above the terrain."
+    "- Notice the use of the `observer_elev` argument, which is the height of the observer above the terrain."
    ]
   },
   {
@@ -597,14 +581,11 @@
     "OBSERVER_X = 0.0\n",
     "OBSERVER_Y = 0.0\n",
     "\n",
-    "observer_df = pd.DataFrame({\n",
-    "   'x': [OBSERVER_X],\n",
-    "   'y': [OBSERVER_Y]\n",
-    "})\n",
+    "observer_df = pd.DataFrame({'x': [OBSERVER_X],'y': [OBSERVER_Y]})\n",
     "observer_agg = cvs.points(observer_df, 'x', 'y')\n",
-    "observer_shaded = dynspread(shade(observer_agg, cmap=['orange',  'orange']),\n",
-    "                            threshold=1,\n",
-    "                            max_px=4)\n",
+    "observer_shaded = dynspread(shade(observer_agg, cmap=['orange']),\n",
+    "                            threshold=1, max_px=4)\n",
+    "\n",
     "stack(shade(illuminated, cmap=['black', 'white'], alpha=128, how='linear'),\n",
     "      terrain_shaded,\n",
     "      observer_shaded)"
@@ -616,16 +597,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Slow Running...\n",
-    "view = viewshed(terrain, x=OBSERVER_X, y=OBSERVER_Y, observer_elev=100)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "%time view = viewshed(terrain, x=OBSERVER_X, y=OBSERVER_Y, observer_elev=100)\n",
+    "\n",
     "view_shaded = shade(view, cmap='fuchsia', how='linear')\n",
     "stack(shade(illuminated, cmap=['black', 'white'], alpha=128, how='linear'),\n",
     "      terrain_shaded,\n",
@@ -637,19 +610,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Zonal Statistics"
+    "The fuchsia areas are those visible to an observer of the given height at the indicated orange location."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Zonal statistics allows for calulating summary statistics for specific areas or *zones* within a datashader aggregate. Zones are defined by creating an integer aggregate where the cell values are zone_ids.  The output of zonal statistics is a pandas dataframe containing summary statistics for each zone based on a value raster.\n",
+    "## Zonal Statistics\n",
+    "\n",
+    "Zonal statistics allows for calculating summary statistics for specific areas or *zones* within a datashader aggregate. Zones are defined by creating an integer aggregate where the cell values are zone_ids.  The output of zonal statistics is a Pandas dataframe containing summary statistics for each zone based on a value raster.\n",
     "\n",
     "Imagine the following scenario:\n",
     "- You are a hiker on a six-day-trip.\n",
     "- The path for each day is defined by a line segement.\n",
-    "- You wish to calculate the mean, max, min elevations for each hiking segement as a pandas dataframe based on an elevation dataset."
+    "- You wish to calculate the max and min elevations for each hiking segment as a Pandas dataframe based on an elevation dataset."
    ]
   },
   {
@@ -681,9 +656,7 @@
     "zones_agg.values = np.nan_to_num(zones_agg.values, copy=False).astype(np.int)\n",
     "zones_shaded = dynspread(shade(zones_agg, cmap=Set1), max_px=5)\n",
     "\n",
-    "stack(illuminated_shaded,\n",
-    "      terrain_shaded,\n",
-    "      zones_shaded)"
+    "stack(illuminated_shaded, terrain_shaded, zones_shaded)"
    ]
   },
   {
@@ -701,7 +674,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### Add a custom stats for each zone"
+    "##### Calculate custom stats for each zone"
    ]
   },
   {
@@ -721,6 +694,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Here the zones are defined by line segments, but they can be any spatial pattern, and in particular can be any region computable as a Datashader aggregate.\n",
+    "\n",
+    "\n",
     "### References\n",
     "- Burrough, P. A., and McDonell, R. A., 1998. Principles of Geographical Information Systems (Oxford University Press, New York), p. 406.\n",
     "- Making Maps with Noise Functions: https://www.redblobgames.com/maps/terrain-from-noise/\n",

--- a/examples/user_guide/8_Geography.ipynb
+++ b/examples/user_guide/8_Geography.ipynb
@@ -113,8 +113,8 @@
     "from datashader.transfer_functions import shade, stack\n",
     "from datashader.colors import Elevation\n",
     "\n",
-    "W = 600\n",
-    "H = 400\n",
+    "W = 1000\n",
+    "H = 750\n",
     "\n",
     "cvs = ds.Canvas(plot_width=W, plot_height=H, x_range=(-20e6, 20e6), y_range=(-20e6, 20e6))\n",
     "terrain = dsgeo.generate_terrain(cvs)\n",
@@ -262,7 +262,14 @@
     "## Bump\n",
     "Bump mapping is a cartographic technique that can be used to create the appearance of trees or other land features.\n",
     "\n",
-    "`dsgeo.bump` will produce a bump aggregate for adding detail to the terrain.  In this case, we will pretend the bumps are trees, and shade them with green."
+    "`dsgeo.bump` will produce a bump aggregate for adding detail to the terrain.\n",
+    "\n",
+    "In this case, we will pretend the bumps are trees, and shade them with green.\n",
+    "\n",
+    "- Let's start by created a user-defined `height_func` for use in bump mapping.\n",
+    "- For this example, I want to vary the density and height of trees at different elevations, which I can do by making `min_elevation`, `max_elevation`, and height arguments to my `height_func`.\n",
+    "- The function ultimately should require only 1 argument (`locations`), which will achieve through using `functools.partial`.\n",
+    "- For additional performance, I add the `ngjit` decorator to the custom `height_func`."
    ]
   },
   {
@@ -272,26 +279,58 @@
    "outputs": [],
    "source": [
     "from functools import partial\n",
+    "from datashader.utils import ngjit\n",
     "\n",
-    "def heights(locations, min_val, max_val, height):\n",
-    "    out = np.zeros(len(locations))\n",
-    "    for i, (x, y) in enumerate(locations):\n",
-    "        val = terrain.data[y, x]\n",
-    "        out[i] = height if (val > min_val and val < max_val) else 0\n",
+    "@ngjit\n",
+    "def height_func(locations, elevation_source, min_elevation, max_elevation, height=20):\n",
+    "    '''Example user-defined height_func for bump mapping which varies bump height by elevation thresholding\n",
+    "    \n",
+    "    Returns\n",
+    "    -------\n",
+    "    out: 1D array of heights for each location\n",
+    "    \n",
+    "    '''\n",
+    "    num_bumps = locations.shape[0]\n",
+    "    out = np.zeros(num_bumps, dtype=np.uint16)\n",
+    "    for r in range(0, num_bumps):\n",
+    "        loc = locations[r]\n",
+    "        x = loc[0]\n",
+    "        y = loc[1]\n",
+    "        val = elevation_source[y, x]\n",
+    "        if val >= min_elevation and val < max_elevation:\n",
+    "            out[r] = height\n",
     "    return out\n",
     "\n",
-    "T = 100000\n",
+    "low_elevation_tree_heights = partial(height_func, elevation_source=terrain.data, min_elevation=1000, max_elevation=2000, height=10)\n",
+    "mid_elevation_tree_heights = partial(height_func, elevation_source=terrain.data, min_elevation=2000, max_elevation=3000, height=5)\n",
+    "high_elevation_tree_heights = partial(height_func, elevation_source=terrain.data, min_elevation=3000, max_elevation=5000, height=5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's use our custom `height_func` with `dsgeo.bump`..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TREE_COUNT = int(3e5)\n",
     "\n",
-    "trees = dsgeo.bump(W, H, count=T, height_func=\n",
-    "                   partial(heights, min_val=1300,  max_val=1700, height=20))\n",
+    "trees = dsgeo.bump(W, H, count=TREE_COUNT, height_func=low_elevation_tree_heights)\n",
+    "trees += dsgeo.bump(W, H, count=TREE_COUNT // 2, height_func=mid_elevation_tree_heights)\n",
+    "trees += dsgeo.bump(W, H, count=TREE_COUNT // 3, height_func=high_elevation_tree_heights)\n",
     "\n",
     "tree_colorize = trees.copy()\n",
     "tree_colorize.data[tree_colorize.data == 0] = np.nan\n",
-    "hillshade = dsgeo.hillshade(terrain + trees)\n",
     "\n",
-    "stack(shade(terrain,        cmap=['black', 'white'], how='linear'),\n",
-    "      shade(hillshade,      cmap=['black', 'white'], how='linear', alpha=128),\n",
-    "      shade(tree_colorize,  cmap='limegreen',        how='linear'))"
+    "stack(shade(terrain + trees,                  cmap=['black', 'white'], how='linear'),\n",
+    "      shade(dsgeo.hillshade(terrain + trees), cmap=['black', 'white'], how='linear', alpha=128),\n",
+    "      shade(tree_colorize,                    cmap='limegreen',        how='linear'))"
    ]
   },
   {
@@ -340,7 +379,7 @@
    "source": [
     "stack(shade(terrain,       cmap=Elevation,          how='linear'),\n",
     "      shade(water,         cmap=['aqua','white']),\n",
-    "      shade(hillshade,     cmap=['black', 'white'], how='linear', alpha=128),\n",
+    "      shade(dsgeo.hillshade(terrain + trees),   cmap=['black', 'white'], how='linear', alpha=128),\n",
     "      shade(tree_colorize, cmap='limegreen',        how='linear'))"
    ]
   },
@@ -578,6 +617,8 @@
     "terrain = dsgeo.generate_terrain(cvs)\n",
     "terrain_shaded = shade(terrain, cmap=Elevation, alpha=128, how='linear')\n",
     "\n",
+    "illuminated = dsgeo.hillshade(terrain)\n",
+    "\n",
     "OBSERVER_X = 0.0\n",
     "OBSERVER_Y = 0.0\n",
     "\n",
@@ -635,8 +676,8 @@
    "source": [
     "from datashader.colors import Set1\n",
     "\n",
-    "W = 600\n",
-    "H = 400\n",
+    "W = 1000\n",
+    "H = 750\n",
     "\n",
     "cvs = ds.Canvas(plot_width=W, plot_height=H, x_range=(-20, 20), y_range=(-20, 20))\n",
     "\n",
@@ -667,7 +708,7 @@
    "source": [
     "from datashader.spatial import zonal_stats\n",
     "\n",
-    "elevation_df = zonal_stats(zones_agg, terrain)"
+    "zonal_stats(zones_agg, terrain)"
    ]
   },
   {

--- a/examples/user_guide/8_Geography.ipynb
+++ b/examples/user_guide/8_Geography.ipynb
@@ -113,8 +113,8 @@
     "from datashader.transfer_functions import shade, stack\n",
     "from datashader.colors import Elevation\n",
     "\n",
-    "W = 1000\n",
-    "H = 750\n",
+    "W = 800\n",
+    "H = 600\n",
     "\n",
     "cvs = ds.Canvas(plot_width=W, plot_height=H, x_range=(-20e6, 20e6), y_range=(-20e6, 20e6))\n",
     "terrain = dsgeo.generate_terrain(cvs)\n",
@@ -260,16 +260,16 @@
    "metadata": {},
    "source": [
     "## Bump\n",
-    "Bump mapping is a cartographic technique that can be used to create the appearance of trees or other land features.\n",
+    "\n",
+    "Bump mapping is a cartographic technique that can be used to create the appearance of trees or other land features, which is useful when synthesizing human-interpretable images from source data like land use classifications.\n",
     "\n",
     "`dsgeo.bump` will produce a bump aggregate for adding detail to the terrain.\n",
     "\n",
-    "In this case, we will pretend the bumps are trees, and shade them with green.\n",
+    "In this example, we will pretend the bumps are trees, and shade them with green.  We'll also use the elevation data to modulate whether there are trees and if so how tall they are.\n",
     "\n",
-    "- Let's start by created a user-defined `height_func` for use in bump mapping.\n",
-    "- For this example, I want to vary the density and height of trees at different elevations, which I can do by making `min_elevation`, `max_elevation`, and height arguments to my `height_func`.\n",
-    "- The function ultimately should require only 1 argument (`locations`), which will achieve through using `functools.partial`.\n",
-    "- For additional performance, I add the `ngjit` decorator to the custom `height_func`."
+    "- First, we'll define a custom `height` function to return tree heights suitable for the given elevation range\n",
+    "- `dsgeo.bump` accepts a function with only a single argument (`locations`), so we will use `functools.partial` to provide values for the other arguments.\n",
+    "- Bump mapping isn't normally a performance bottleneck, but if you want, you can speed it up by using Numba on your custom `height` function (`from datashader.utils import ngjit`, then put `@ngjit` above `def heights(...)`)."
    ]
   },
   {
@@ -279,58 +279,32 @@
    "outputs": [],
    "source": [
     "from functools import partial\n",
-    "from datashader.utils import ngjit\n",
     "\n",
-    "@ngjit\n",
-    "def height_func(locations, elevation_source, min_elevation, max_elevation, height=20):\n",
-    "    '''Example user-defined height_func for bump mapping which varies bump height by elevation thresholding\n",
-    "    \n",
-    "    Returns\n",
-    "    -------\n",
-    "    out: 1D array of heights for each location\n",
-    "    \n",
-    "    '''\n",
+    "def heights(locations, src, src_range, height=20):\n",
     "    num_bumps = locations.shape[0]\n",
     "    out = np.zeros(num_bumps, dtype=np.uint16)\n",
     "    for r in range(0, num_bumps):\n",
     "        loc = locations[r]\n",
     "        x = loc[0]\n",
     "        y = loc[1]\n",
-    "        val = elevation_source[y, x]\n",
-    "        if val >= min_elevation and val < max_elevation:\n",
+    "        val = src[y, x]\n",
+    "        if val >= src_range[0] and val < src_range[1]:\n",
     "            out[r] = height\n",
     "    return out\n",
     "\n",
-    "low_elevation_tree_heights = partial(height_func, elevation_source=terrain.data, min_elevation=1000, max_elevation=2000, height=10)\n",
-    "mid_elevation_tree_heights = partial(height_func, elevation_source=terrain.data, min_elevation=2000, max_elevation=3000, height=5)\n",
-    "high_elevation_tree_heights = partial(height_func, elevation_source=terrain.data, min_elevation=3000, max_elevation=5000, height=5)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now let's use our custom `height_func` with `dsgeo.bump`..."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "TREE_COUNT = int(3e5)\n",
-    "\n",
-    "trees = dsgeo.bump(W, H, count=TREE_COUNT, height_func=low_elevation_tree_heights)\n",
-    "trees += dsgeo.bump(W, H, count=TREE_COUNT // 2, height_func=mid_elevation_tree_heights)\n",
-    "trees += dsgeo.bump(W, H, count=TREE_COUNT // 3, height_func=high_elevation_tree_heights)\n",
+    "T = 300000 # Number of trees to add per call\n",
+    "src = terrain.data\n",
+    "%time trees  = dsgeo.bump(W, H, count=T,    height_func=partial(heights, src=src, src_range=(1000, 1300), height=5))\n",
+    "trees       += dsgeo.bump(W, H, count=T//2, height_func=partial(heights, src=src, src_range=(1300, 1700), height=20))\n",
+    "trees       += dsgeo.bump(W, H, count=T//3, height_func=partial(heights, src=src, src_range=(1700, 2000), height=5))\n",
     "\n",
     "tree_colorize = trees.copy()\n",
     "tree_colorize.data[tree_colorize.data == 0] = np.nan\n",
+    "hillshade = dsgeo.hillshade(terrain + trees)\n",
     "\n",
-    "stack(shade(terrain + trees,                  cmap=['black', 'white'], how='linear'),\n",
-    "      shade(dsgeo.hillshade(terrain + trees), cmap=['black', 'white'], how='linear', alpha=128),\n",
-    "      shade(tree_colorize,                    cmap='limegreen',        how='linear'))"
+    "stack(shade(terrain,        cmap=['black', 'white'], how='linear'),\n",
+    "      shade(hillshade,      cmap=['black', 'white'], how='linear', alpha=128),\n",
+    "      shade(tree_colorize,  cmap='limegreen',        how='linear'))"
    ]
   },
   {
@@ -676,8 +650,8 @@
    "source": [
     "from datashader.colors import Set1\n",
     "\n",
-    "W = 1000\n",
-    "H = 750\n",
+    "W = 800\n",
+    "H = 600\n",
     "\n",
     "cvs = ds.Canvas(plot_width=W, plot_height=H, x_range=(-20, 20), y_range=(-20, 20))\n",
     "\n",


### PR DESCRIPTION
Various fixes for the geospatial toolbox, mostly in the docs.

- Restored missing full-archipelago rendering example
- Fixed broken bump mapping example (had too few trees to see)
- Replaced GeoViews with HoloViews tiles. 
- Replaced NDVI example with a more interpretable image
- Fixed initial points display for web page. 
- Made shoreline more visible
- Use numpy arrays to make Numba happy (was warning in some cases due to potentially heterogenous lists)