### PR TITLE
Fix typo in ToC

### DIFF
--- a/examples/user_guide/8_Geography.ipynb
+++ b/examples/user_guide/8_Geography.ipynb
@@ -10,7 +10,7 @@
     "* [Generate terrain](#Generate-terrain)\n",
     "* [Hillshade](#Hillshade)\n",
     "* [Slope](#Slope)\n",
-    "* [Aspect](#Aspecct)\n",
+    "* [Aspect](#Aspect)\n",
     "* [Bump map](#Bump-map)\n",
     "* [NDVI](#NDVI)\n",
     "* [Mean](#Mean)\n",


### PR DESCRIPTION
The `Aspect` link (ToC) of this Geography nb/page was pointing to `Aspecct` (non-existent).